### PR TITLE
Add k3s-channel input

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -27,19 +27,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - k3s-channel: latest
+          - k3s-version: ""
+            k3s-channel: latest
             helm-version: ""
-          - k3s-version: v1.19.3+k3s1
-            helm-version: v3.3.4
-          - k3s-version: v1.18.10+k3s1
+          - k3s-version: ""
+            k3s-channel: v1.19
+            helm-version: v3.4.2
+          - k3s-version: ""
+            k3s-channel: v1.18
             helm-version: v3.3.4
           - k3s-version: v1.17.13+k3s1
+            k3s-channel: ""
             helm-version: v3.2.4
           - k3s-version: v1.16.15+k3s1
+            k3s-channel: ""
             helm-version: v3.1.3
     steps:
       - uses: actions/checkout@v2
-      - id: k3s
+      - name: Local action
+        id: k3s
         uses: ./
         with:
           k3s-version: ${{ matrix.k3s-version }}
@@ -82,7 +88,8 @@ jobs:
     name: Test K3s options
     steps:
       - uses: actions/checkout@v2
-      - id: k3s
+      - name: Local action
+        id: k3s
         uses: ./
         with:
           k3s-version: ""

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -1,7 +1,10 @@
 ---
 name: Test
 
-# yamllint disable-line rule:truthy
+# Inline config of yamllint, ref: https://yamllint.readthedocs.io/
+#
+# yamllint disable rule:line-length
+
 on:
   pull_request:
   push:

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -5,6 +5,7 @@ name: Test
 on:
   pull_request:
   push:
+  workflow_dispatch:
 
 jobs:
   # https://github.com/pre-commit/action
@@ -20,23 +21,27 @@ jobs:
     runs-on: ubuntu-latest
     name: Test K3s and Helm
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - k3s: v1.19.3+k3s1
-            helm: v3.3.4
-          - k3s: v1.18.10+k3s1
-            helm: v3.3.4
-          - k3s: v1.17.13+k3s1
-            helm: v3.2.4
-          - k3s: v1.16.15+k3s1
-            helm: v3.1.3
+          - k3s-channel: latest
+            helm-version: ""
+          - k3s-version: v1.19.3+k3s1
+            helm-version: v3.3.4
+          - k3s-version: v1.18.10+k3s1
+            helm-version: v3.3.4
+          - k3s-version: v1.17.13+k3s1
+            helm-version: v3.2.4
+          - k3s-version: v1.16.15+k3s1
+            helm-version: v3.1.3
     steps:
       - uses: actions/checkout@v2
       - id: k3s
         uses: ./
         with:
-          k3s-version: ${{ matrix.k3s }}
-          helm-version: ${{ matrix.helm }}
+          k3s-version: ${{ matrix.k3s-version }}
+          k3s-channel: ${{ matrix.k3s-channel }}
+          helm-version: ${{ matrix.helm-version }}
           metrics-enabled: true
           traefik-enabled: true
           docker-enabled: false
@@ -50,7 +55,7 @@ jobs:
           # These options should be enabled
           kubectl get --namespace kube-system deploy metrics-server
           # Problem with 1.16, ignore since it'll be dropped soon
-          if [[ "${{ matrix.k3s }}" != v1.16.* ]]; then
+          if [[ "${{ matrix.k3s-version }}${{ matrix.k3s-channel }}" != v1.16.* ]]; then
               kubectl get --namespace kube-system deploy traefik
           fi
         shell: bash
@@ -78,6 +83,7 @@ jobs:
         uses: ./
         with:
           k3s-version: ""
+          k3s-channel: ""
           helm-version: ""
           metrics-enabled: false
           traefik-enabled: false

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # GitHub Action: Install K3s, Calico and Helm
 [![GitHub Action badge](https://github.com/manics/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/manics/action-k3s-helm/actions)
 
-Install K3s with Calico for network policies, and Helm 3.
+Install K3s (1.16+), Calico (3.16) for network policy enforcement, and Helm (3.1+).
 
 
 ## Optional input parameters
-- `k3s-version`: K3s version, see https://github.com/rancher/k3s/releases.
-   Versions 1.16 and later are supported. Defaults to the latest version.
-- `helm-version`: Helm version, see https://github.com/helm/helm/releases.
-   Versions 3.1 and later are supported. Defaults to the latest version.
+- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.16 and later are supported. Defaults to the stable channel.
+- `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.1 and later are supported. Defaults to the latest version.
 - `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
 - `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.
 - `docker-enabled`: Enable K3s to use the Docker daemon, `true` or `false` (default).

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: K3S version (https://github.com/rancher/k3s/releases)
     required: false
     default: ""
+  k3s-channel:
+    description: K3S channel (https://update.k3s.io/v1-release/channels)
+    required: false
+    default: ""
   helm-version:
     description: Helm 3 version (https://github.com/helm/helm/releases)
     required: false
@@ -59,9 +63,16 @@ runs:
     #
     # NOTE: k3s 1.16 and older needed a flag named --no-deploy instead of
     #       --disable.
-    - name: Setup k3s ${{ inputs.k3s-version }}
+    - name: Validate input
       run: |
-        if [[ "${{ inputs.k3s-version }}" == v1.16.* ]]; then
+        if [[ -n "${{ inputs.k3s-version }}" && -n "${{ inputs.k3s-channel }}" ]]; then
+          echo "k3s-version and k3s-channel must not be specified simultaneously!"
+          exit 1
+        fi
+      shell: bash
+    - name: Setup k3s ${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
+      run: |
+        if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.16.* ]]; then
           k3s_disable_command=--no-deploy
         else
           k3s_disable_command=--disable
@@ -75,7 +86,7 @@ runs:
         if [[ "${{ inputs.docker-enabled }}" == true ]]; then
           k3s_docker=--docker
         fi
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" sh -s - \
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
           --write-kubeconfig-mode=644 \
           ${k3s_disable_metrics} \
           ${k3s_disable_traefik} \
@@ -129,7 +140,7 @@ runs:
           kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
         fi
         # Problem with 1.16, ignore since it'll be dropped soon
-        if [[ "${{ inputs.traefik-enabled }}" == true && "${{ inputs.k3s-version }}" != v1.16.* ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" == true && "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" != v1.16.* ]]; then
           kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
         fi
       shell: bash


### PR DESCRIPTION
This PR provides support for providing k3s-channel as input instead of k3s-version.

A typical use case for this could be for example to install the latest release of k3s by specifying `k3s-channel: latest`. The default behavior of the k3s install script is to rely on the `stable` channel unless version/channel is specified. The difference between latest/stable is currently 1.20.x/1.19.y.

---

I considered setting INSTALL_K3S_CHANNEL as an environment variable on the action to influence it, but I concluded it wouldn't work for k3s 1.16 as there was a workaround in place using the k3s-version in its logic.

My motivation for developing this feature is that I'd like to make some CI tests test against the latest patch version rather than a pinned one. While it can be useful to pin versions to not see them break, it can also be useful to have them fluid to spot compatibility with new versions.

Adding this new input goes against the principle in the README.md about minimizing features of the action, but I just felt it was so fundamental for the action in parity with the other inputs and wasn't hard to test. I'm open to the idea of closing this PR, but I'm certainly also willing to do maintenance work associated with this.

Related issue: https://github.com/jupyterhub/action-k3s-helm/issues/5
