### PR TITLE
Bump Calico to 3.17 (3.17.1 implicitly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Action: Install K3s, Calico and Helm
 [![GitHub Action badge](https://github.com/manics/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/manics/action-k3s-helm/actions)
 
-Install K3s (1.16+), Calico (3.16) for network policy enforcement, and Helm (3.1+).
+Install K3s (1.16+), Calico (3.17) for network policy enforcement, and Helm (3.1+).
 
 
 ## Optional input parameters

--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
     #
     - name: Setup calico
       run: |
-        curl -sfL https://docs.projectcalico.org/v3.16/manifests/calico.yaml \
+        curl -sfL https://docs.projectcalico.org/v3.17/manifests/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\
               "allow_ip_forwarding": true\


### PR DESCRIPTION
Just keeping it updated, not aware of any bug fix would be relevant or
not for any project relying on this action. The release of 3.17.0 was
made 23 Nov 2020, while 3.17.1 was made 10 Dec 2020. At this point I
think a bump would be safe from the initial bleeding edge issues.

## A calico-version input? I don't think so.
I considered if we want to have a calico-version input, but I think we don't. Then we would end up needing to keep track of version we support and if there are different versions that come with special quirks it would become really troublesome to grid-test k3s + calico versions etc. So, my thinking is that it makes sense to have this pinned.

---

I committed this change on top of #8 as it was modifying a common line. The PR by itself is really just 8094c17.