### PR TITLE
ci: release automation

### DIFF
--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -23,4 +23,3 @@ jobs:
           # By using branches as identifiers it is still possible to backtrack
           # some patch, but not if we use tags.
           prefer_branch_releases: true
-          publish_latest_tag: true

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -2,7 +2,9 @@
 # release, use the GitHub UI where you enter a tag name and release name of
 # "vX.Y.Z". See https://github.com/jupyterhub/action-k3s-helm/releases.
 #
-#
+# Inline config for yamllint, ref: https://yamllint.readthedocs.io/
+# yamllint disable rule:line-length
+---
 name: Release updates
 
 on:

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
-      - uses: Actions-R-Us/actions-tagger@latest
+      - uses: Actions-R-Us/actions-tagger@c46540b9f3302c3b4e6a7bd622cb478fc98c52be
         env:
           GITHUB_TOKEN: "${{ github.token }}"
         with:

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -1,0 +1,24 @@
+# Automatically updates "vX" branches based on GitHub releases. To cut a new
+# release, use the GitHub UI where you enter a tag name and release name of
+# "vX.Y.Z". See https://github.com/jupyterhub/action-k3s-helm/releases.
+#
+#
+name: Release updates
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: windows-latest
+    steps:
+      # Action reference: https://github.com/Actions-R-Us/actions-tagger
+      - uses: Actions-R-Us/actions-tagger@latest
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+        with:
+          # By using branches as identifiers it is still possible to backtrack
+          # some patch, but not if we use tags.
+          prefer_branch_releases: true
+          publish_latest_tag: true

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -1,9 +1,9 @@
+# Runs tests referencing the local GitHub Action to verify it works as intended.
+#
+# Inline config for yamllint, ref: https://yamllint.readthedocs.io/
+# yamllint disable rule:line-length
 ---
 name: Test
-
-# Inline config of yamllint, ref: https://yamllint.readthedocs.io/
-#
-# yamllint disable rule:line-length
 
 on:
   pull_request:

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -8,6 +8,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches-ignore:
+      - "v*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Closes #10 by using the actions-tagger action. I verified it to work properly on my fork.

---

Disabled runs in vX branches as they are tested by a tag push anyhow.