### PR TITLE
Fix k3s-channel implementation for v1.16 specifically

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -33,7 +33,7 @@ jobs:
             k3s-channel: latest
             helm-version: ""
           - k3s-version: ""
-            k3s-channel: v1.19
+            k3s-channel: stable
             helm-version: v3.4.2
           - k3s-version: ""
             k3s-channel: v1.18
@@ -41,8 +41,8 @@ jobs:
           - k3s-version: v1.17.13+k3s1
             k3s-channel: ""
             helm-version: v3.2.4
-          - k3s-version: v1.16.15+k3s1
-            k3s-channel: ""
+          - k3s-version: ""
+            k3s-channel: v1.16
             helm-version: v3.1.3
     steps:
       - uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
           # These options should be enabled
           kubectl get --namespace kube-system deploy metrics-server
           # Problem with 1.16, ignore since it'll be dropped soon
-          if [[ "${{ matrix.k3s-version }}${{ matrix.k3s-channel }}" != v1.16.* ]]; then
+          if [[ "${{ matrix.k3s-version }}${{ matrix.k3s-channel }}" != v1.16* ]]; then
               kubectl get --namespace kube-system deploy traefik
           fi
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
       shell: bash
     - name: Setup k3s ${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
       run: |
-        if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.16.* ]]; then
+        if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.16* ]]; then
           k3s_disable_command=--no-deploy
         else
           k3s_disable_command=--disable
@@ -140,7 +140,7 @@ runs:
           kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
         fi
         # Problem with 1.16, ignore since it'll be dropped soon
-        if [[ "${{ inputs.traefik-enabled }}" == true && "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" != v1.16.* ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" == true && "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" != v1.16* ]]; then
           kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
         fi
       shell: bash


### PR DESCRIPTION
There was pattern matching assuming against "v1.16.*", but the k3s-channel input won't have the dot. This PR fixes the issue by removing the dot from the pattern match.

Spotted when trying it out in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/1973