### PR TITLE
Add version outputs and test set output and env

### DIFF
--- a/.github/workflows/readme_example.yml
+++ b/.github/workflows/readme_example.yml
@@ -1,7 +1,5 @@
 # This workflow is meant to verify the example we keep in the README.md is
 # functional. Due to this, we need to make sure we keep it in sync.
-#
-# yamllint disable rule:line-length
 ---
 name: Example workflow
 

--- a/.github/workflows/readme_example.yml
+++ b/.github/workflows/readme_example.yml
@@ -10,6 +10,10 @@ on:
   push:
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   k8s-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/readme_example.yml
+++ b/.github/workflows/readme_example.yml
@@ -8,10 +8,6 @@ on:
   push:
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   k8s-test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -8,10 +8,6 @@ on:
   release:
     types: [published, edited]
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   actions-tagger:
     runs-on: windows-latest

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -1,9 +1,6 @@
 # Automatically updates "vX" branches based on GitHub releases. To cut a new
 # release, use the GitHub UI where you enter a tag name and release name of
 # "vX.Y.Z". See https://github.com/jupyterhub/action-k3s-helm/releases.
-#
-# Inline config for yamllint, ref: https://yamllint.readthedocs.io/
-# yamllint disable rule:line-length
 ---
 name: Release updates
 

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -11,6 +11,10 @@ on:
   release:
     types: [published, edited]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   actions-tagger:
     runs-on: windows-latest

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -12,6 +12,10 @@ on:
       - "v*"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # https://github.com/pre-commit/action
   pre-commit:
@@ -69,21 +73,17 @@ jobs:
           if [[ "${{ matrix.k3s-version }}${{ matrix.k3s-channel }}" != v1.16* ]]; then
               kubectl get --namespace kube-system deploy traefik
           fi
-        shell: bash
 
       - name: Helm
         run: |
           helm version
           helm list
-        shell: bash
 
       - name: Install network policies test
         run: helm install test-calico ./test-calico --wait
-        shell: bash
 
       - name: Run network policies test
         run: helm test test-calico --logs
-        shell: bash
 
   test_install_k3s_options:
     runs-on: ubuntu-latest
@@ -118,7 +118,6 @@ jobs:
           fi
           docker info
           docker ps
-        shell: bash
 
   # Provides a single status_all check that can be used in GitHub branch
   # protection rules instead of having to list each matrix job

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -60,7 +60,31 @@ jobs:
           metrics-enabled: true
           traefik-enabled: true
           docker-enabled: false
-      # This action should export KUBECONFIG
+
+      - name: Action's set outputs and env
+        run: |
+          EXIT=0
+          if [[ -z "${KUBECONFIG}" ]]; then
+              echo "KUBECONFIG not set as an environment variable"
+              EXIT=1
+          fi
+          if [[ -z "${{ steps.k3s.outputs.kubeconfig }}" ]]; then
+              echo "kubeconfig not set as an action output"
+              EXIT=1
+          fi
+          if [[ -z "${{ steps.k3s.outputs.k3s-version }}" ]]; then
+              echo "k3s-version not set as an action output"
+              EXIT=1
+          fi
+          if [[ -z "${{ steps.k3s.outputs.k8s-version }}" ]]; then
+              echo "k8s-version not set as an action output"
+              EXIT=1
+          fi
+          if [[ -z "${{ steps.k3s.outputs.helm-version }}" ]]; then
+              echo "helm-version not set as an action output"
+              EXIT=1
+          fi
+          exit $EXIT
 
       - name: Kubectl
         run: |
@@ -100,7 +124,6 @@ jobs:
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true
-      # This action should export KUBECONFIG
 
       - name: Kubectl
         run: |

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -66,6 +66,7 @@ jobs:
           echo "k8s-version=${{ steps.k3s.outputs.k8s-version }}"
           echo "calico-version=${{ steps.k3s.outputs.calico-version }}"
           echo "helm-version=${{ steps.k3s.outputs.helm-version }}"
+          echo "---"
 
           EXIT=0
           if [[ -z "${KUBECONFIG}" ]]; then
@@ -76,20 +77,20 @@ jobs:
               echo "kubeconfig not set as an action output"
               EXIT=1
           fi
-          if [[ -z "${{ steps.k3s.outputs.k3s-version }}" ]]; then
-              echo "k3s-version not set as an action output"
+          if [[ "${{ steps.k3s.outputs.k3s-version }}" != v* ]]; then
+              echo "k3s-version not set correctly as an action output"
               EXIT=1
           fi
-          if [[ -z "${{ steps.k3s.outputs.k8s-version }}" ]]; then
-              echo "k8s-version not set as an action output"
+          if [[ "${{ steps.k3s.outputs.k8s-version }}" != v* ]]; then
+              echo "k8s-version not set correctly as an action output"
               EXIT=1
           fi
-          if [[ -z "${{ steps.k3s.outputs.calico-version }}" ]]; then
-              echo "calico-version not set as an action output"
+          if [[ "${{ steps.k3s.outputs.calico-version }}" != v* ]]; then
+              echo "calico-version not set correctly as an action output"
               EXIT=1
           fi
-          if [[ -z "${{ steps.k3s.outputs.helm-version }}" ]]; then
-              echo "helm-version not set as an action output"
+          if [[ "${{ steps.k3s.outputs.helm-version }}" != v* ]]; then
+              echo "helm-version not set correctly as an action output"
               EXIT=1
           fi
 

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -63,6 +63,13 @@ jobs:
 
       - name: Action's set outputs and env
         run: |
+          echo "KUBECONFIG=${KUBECONFIG}"
+          echo "kubeconfig=${{ steps.k3s.outputs.kubeconfig }}"
+          echo "k3s-version=${{ steps.k3s.outputs.k3s-version }}"
+          echo "k8s-version=${{ steps.k3s.outputs.k8s-version }}"
+          echo "calico-version=${{ steps.k3s.outputs.calico-version }}"
+          echo "helm-version=${{ steps.k3s.outputs.helm-version }}"
+
           EXIT=0
           if [[ -z "${KUBECONFIG}" ]]; then
               echo "KUBECONFIG not set as an environment variable"
@@ -80,10 +87,15 @@ jobs:
               echo "k8s-version not set as an action output"
               EXIT=1
           fi
+          if [[ -z "${{ steps.k3s.outputs.calico-version }}" ]]; then
+              echo "calico-version not set as an action output"
+              EXIT=1
+          fi
           if [[ -z "${{ steps.k3s.outputs.helm-version }}" ]]; then
               echo "helm-version not set as an action output"
               EXIT=1
           fi
+
           exit $EXIT
 
       - name: Kubectl

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -9,10 +9,6 @@ on:
       - "v*"
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   # https://github.com/pre-commit/action
   pre-commit:

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -1,7 +1,4 @@
 # Runs tests referencing the local GitHub Action to verify it works as intended.
-#
-# Inline config for yamllint, ref: https://yamllint.readthedocs.io/
-# yamllint disable rule:line-length
 ---
 name: Test
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,5 @@ repos:
     rev: v1.25.0
     hooks:
       - id: yamllint
+        args:
+          - --config-data=relaxed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ enforcement, and installs [Helm](https://helm.sh/) (3.1+).
 ## Outputs
 - `kubeconfig`: The absolute path to the kubeconfig file (`$HOME/.kube/config`).
   The `KUBECONFIG` environment variable is also set by this action but may be removed in a future breaking release.
+- `k3s-version`: Installed k3s version, such as v1.20.0+k3s2
+- `k8s-version`: Installed k8s version, such as v1.20.0
+- `calico-version`: Installed calico version, such as v3.17.1
+- `helm-version`: Installed helm version, such as v3.4.2
 
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,13 @@
----
+# This is the GitHub Action definition file, similar to a GitHub Workflow but
+# different. Noteworthy differences are for example that we cannot set
+# defaults.run.shell=bash, and any output we set in collective steps must be
+# re-mapped under the outputs field.
+#
 # yamllint disable rule:line-length
+#
+# Reference: https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/metadata-syntax-for-github-actions
+#
+---
 
 name: K3S with Calico and Helm
 description: |
@@ -48,6 +56,18 @@ outputs:
   kubeconfig:
     description: Path to kubeconfig file
     value: ${{ env.KUBECONFIG }}
+  k3s-version:
+    description: "Installed k3s version, such as v1.20.0+k3s2"
+    value: "${{ steps.set-output.outputs.k3s-version }}"
+  k8s-version:
+    description: "Installed k8s version, such as v1.20.0"
+    value: "${{ steps.set-output.outputs.k8s-version }}"
+  calico-version:
+    description: "Installed calico version, such as v3.17.1"
+    value: "${{ steps.set-output.outputs.calico-version }}"
+  helm-version:
+    description: "Installed helm version, such as v3.4.2"
+    value: "${{ steps.set-output.outputs.helm-version }}"
 
 runs:
   using: "composite"
@@ -114,7 +134,8 @@ runs:
     #
     - name: Setup calico
       run: |
-        curl -sfL https://docs.projectcalico.org/v3.17/manifests/calico.yaml \
+        curl -sfL --output /tmp/calico.yaml https://docs.projectcalico.org/v3.17/manifests/calico.yaml
+        cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\
               "allow_ip_forwarding": true\
@@ -128,6 +149,15 @@ runs:
     - name: Setup Helm ${{ inputs.helm-version }}
       run: |
         curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION="${{ inputs.helm-version }}" bash
+      shell: bash
+
+    - name: Set version output
+      id: set-output
+      run: |
+        echo "::set-output name=k3s-version::$(k3s --version | sed 's/.*\(v[0-9][^ ]*\).*/\1/')"
+        echo "::set-output name=k8s-version::$(k3s --version | sed 's/.*\(v[0-9][^+]*\).*/\1/')"
+        echo "::set-output name=calico-version::$(cat /tmp/calico.yaml | grep --max-count=1 "calico/cni:v" | sed 's/.*calico\/cni:\(.*\)/\1/')"
+        echo "::set-output name=helm-version::$(helm version --short | sed 's/\([^+]*\).*/\1/')"
       shell: bash
 
     - name: Wait for calico

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
 outputs:
   kubeconfig:
     description: Path to kubeconfig file
-    value: ${{ env.KUBECONFIG }}
+    value: ${{ steps.set-output.outputs.kubeconfig }}
   k3s-version:
     description: "Installed k3s version, such as v1.20.0+k3s2"
     value: "${{ steps.set-output.outputs.k3s-version }}"
@@ -154,6 +154,7 @@ runs:
     - name: Set version output
       id: set-output
       run: |
+        echo "::set-output name=kubeconfig::$HOME/.kube/config"
         echo "::set-output name=k3s-version::$(k3s --version | sed 's/.*\(v[0-9][^ ]*\).*/\1/')"
         echo "::set-output name=k8s-version::$(k3s --version | sed 's/.*\(v[0-9][^+]*\).*/\1/')"
         echo "::set-output name=calico-version::$(cat /tmp/calico.yaml | grep --max-count=1 "calico/cni:v" | sed 's/.*calico\/cni:\(.*\)/\1/')"


### PR DESCRIPTION
Closes #14 by implementing the suggested feature to provide version outputs.

Added:
- k3s-version/k8s-version/calico-version/helm-version
- Trivial tests to ensure output is set (non empty / start with v)
- Docs in README

CI changes:
- Added defaults.run.shell=bash
- Relaxes yamllint to not bug as much by using the relaxed defaults. I got frustrated by the line-length rule especially, and found that the truthy rule was just adding noise.

![image](https://user-images.githubusercontent.com/3837114/103393242-05033680-4b22-11eb-9c2c-a324f6507196.png)

---

@manics I'll go ahead and release 1.1.0 with this merged. The release system is working well with the `v1` branch etc it seems!