### PR TITLE
Add write permissions to /etc/rancher/k3s

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
           k3s_docker=--docker
         fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
-          --write-kubeconfig-mode=644 \
+          --write-kubeconfig-mode=666 \
           ${k3s_disable_metrics} \
           ${k3s_disable_traefik} \
           --disable-network-policy \

--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,11 @@ runs:
           --flannel-backend=none \
           ${k3s_docker} \
           ${{ inputs.extra-setup-args }}
+
+        # We elevate permissions to allow "kubectl config set-context" to work
+        # without sudo. Apparently k3s.yaml.lock is created when it run, which
+        # requires write privileges.
+        sudo chmod +666 /etc/rancher/k3s
       shell: bash
 
     - name: Export KUBECONFIG environment variable


### PR DESCRIPTION
By giving write permissions to this folder, we avoid permissions errors when trying to use ...

```
kubectl config set-context --current --namespace=some-namespace
```

The entire folder needs write permissions because kubectl config set-context will create a temporary file in the folder before modifying the config file. I also raise the permissions of the kubeconfig file itself to ensure there isn't any issues there either.

Here is the permissions error I ran into.

```
error: open /etc/rancher/k3s/k3s.yaml.lock: permission denied
```

## Workaround

It is possible to workaround this with...

```
sudo --preserve-env kubectl config set-context --current --namespace=some-namespace
```

But why not provide full access to the k3s kubeconfig for the users of this action?