### PR TITLE
Transition to using a kubeconfig in ~/.kube/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # GitHub Action: Install K3s, Calico and Helm
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
-Install K3s (1.16+), Calico (3.17) for network policy enforcement, and Helm (3.1+).
-
+Setups a Kubernetes cluster using [K3s](https://k3s.io/) (1.16+) with
+[Calico](https://www.projectcalico.org/) (3.17) for
+[NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+enforcement, and installs [Helm](https://helm.sh/) (3.1+).
 
 ## Optional input parameters
 - `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.16 and later are supported. Defaults to the stable channel.
@@ -14,8 +16,9 @@ Install K3s (1.16+), Calico (3.17) for network policy enforcement, and Helm (3.1
 
 
 ## Outputs
-- `kubeconfig`: The path to the kube-config file.
-  The `KUBECONFIG` environment variable is also set by this action.
+- `kubeconfig`: The absolute path to the kubeconfig file which is created by the
+  action at the location of what `$HOME/.kube/config` evaluates to. The
+  `KUBECONFIG` environment variable is also set by this action.
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ enforcement, and installs [Helm](https://helm.sh/) (3.1+).
 
 
 ## Outputs
-- `kubeconfig`: The absolute path to the kubeconfig file which is created by the
-  action at the location of what `$HOME/.kube/config` evaluates to. The
-  `KUBECONFIG` environment variable is also set by this action.
+- `kubeconfig`: The absolute path to the kubeconfig file (`$HOME/.kube/config`).
+  The `KUBECONFIG` environment variable is also set by this action but may be removed in a future breaking release.
 
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -99,8 +99,7 @@ runs:
     - name: Prepare a kubeconfig in ~/.kube/config
       run: |
         mkdir -p ~/.kube
-        sudo cp /etc/rancher/k3s/k3s.yaml "$HOME/.kube/config"
-        sudo chown $(id -u):$(id -g) "$HOME/.kube/config"
+        sudo cat /etc/rancher/k3s/k3s.yaml > "$HOME/.kube/config"
         echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
 outputs:
   kubeconfig:
     description: Path to kubeconfig file
-    value: /etc/rancher/k3s/k3s.yaml
+    value: ${{ env.KUBECONFIG }}
 
 runs:
   using: "composite"
@@ -88,7 +88,6 @@ runs:
           k3s_docker=--docker
         fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
-          --write-kubeconfig-mode=644 \
           ${k3s_disable_metrics} \
           ${k3s_disable_traefik} \
           --disable-network-policy \
@@ -97,8 +96,12 @@ runs:
           ${{ inputs.extra-setup-args }}
       shell: bash
 
-    - name: Export KUBECONFIG environment variable
-      run: echo "KUBECONFIG=/etc/rancher/k3s/k3s.yaml" >> $GITHUB_ENV
+    - name: Prepare a kubeconfig in ~/.kube/config
+      run: |
+        mkdir -p ~/.kube
+        sudo cp /etc/rancher/k3s/k3s.yaml "$HOME/.kube/config"
+        sudo chown $(id -u):$(id -g) "$HOME/.kube/config"
+        echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
       shell: bash
 
     # Install calico as a CNI to enforce our NetworkPolicies. Note that canal


### PR DESCRIPTION
Following discussion in https://github.com/jupyterhub/action-k3s-helm/pull/21, this PR does:

1. Makes k3s write the kubeconfig to /etc/rancher/k3s/k3s.yaml without increased permissions
2. Copies the k3s kubeconfig from /etc/rancher/k3s/k3s.yaml to ~/.kube/config and chowns it to be owned by the current user/group.
3. Updates README.md

## Questions
- Should we communicate that this will write to ~/.kube/config in the README? I did it!
- Does this change merit a patch, minor, or major version bump?
- Should we still explicitly set KUBECONFIG?
  I haven't changed this, but I think we should.