### PR TITLE
fix: restrict kubeconfig permissions to current user to avoid helm's warnings

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -109,6 +109,11 @@ jobs:
           helm version
           helm list
 
+          if helm version 2>&1 | grep WARNING > /dev/null; then
+              echo "helm is expected to run without a WARNING!"
+              exit 1
+          fi
+
       - name: Install network policies test
         run: helm install test-calico ./test-calico --wait
 

--- a/action.yml
+++ b/action.yml
@@ -115,10 +115,14 @@ runs:
           ${{ inputs.extra-setup-args }}
       shell: bash
 
+    # By providing a kubeconfig owned by the current user with 600 permissions,
+    # kubectl becomes usable without sudo, and helm won't emit warnings about
+    # bloated access to group/world.
     - name: Prepare a kubeconfig in ~/.kube/config
       run: |
         mkdir -p ~/.kube
         sudo cat /etc/rancher/k3s/k3s.yaml > "$HOME/.kube/config"
+        chmod 600 "$HOME/.kube/config"
         echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
When we copied file we got a file with 600 owned by root user and root group, but when we in 8775112 changed to writing a new file it got 664 permissions.

```diff
-        sudo cp /etc/rancher/k3s/k3s.yaml "$HOME/.kube/config"
-        sudo chown $(id -u):$(id -g) "$HOME/.kube/config"
+        sudo cat /etc/rancher/k3s/k3s.yaml > "$HOME/.kube/config"
```

This PR removes the group/world permissions to ensure we don't get a lot of warnings from whenever `helm` is used etc. Through the added test, it also ensures it works this time.