### PR TITLE
ci: emit a namespace report of kube-system on failure

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -120,6 +120,15 @@ jobs:
       - name: Run network policies test
         run: helm test test-calico --logs
 
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report
+      - name: Kubernetes namespace report
+        if: always()
+        uses: jupyterhub/action-k8s-namespace-report@v1
+        with:
+          # NOTE: This modifies the kubeconfig's current context's default
+          #       namespace as of v1.0.1...
+          namespace: kube-system
+
   test_install_k3s_options:
     runs-on: ubuntu-latest
     name: Test K3s options


### PR DESCRIPTION
I initially considered if we could make it part of the action to debug itself on failure, but it wasn't possible to reference the namespace report action from the action itself. So, instead I'm opting to add a debugging step to our tests of the action.

There is a somewhat seldom occurring intermittent issue where we fail to get up and running, being stuck waiting for calico for example. When this has happened I have had no clear way to debug it, so I figure if it happens within this repo's tests we should at least have some debugging information available.

---

The kind of failures I've seen are the following, and I hope to find more information about this if it happens in general.

```
Waiting for daemon set spec update to be observed...
Waiting for daemon set "calico-node" rollout to finish: 0 out of 1 new pods have been updated...
Waiting for daemon set "calico-node" rollout to finish: 0 of 1 updated pods are available...
daemon set "calico-node" successfully rolled out
Waiting for deployment "calico-kube-controllers" rollout to finish: 0 of 1 updated replicas are available...
error: timed out waiting for the condition
```