### PR TITLE
ci: ensure actions-tagger has the permissions to update branches/tags

### DIFF
--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   actions-tagger:
     runs-on: windows-latest
+    permissions:
+      contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
       # NOTE: We pin a version not to have the source code (.ts files), but the


### PR DESCRIPTION
Based on https://github.com/jupyterhub/action-major-minor-tag-calculator/pull/75, ensures we have the permissions required in our CI setup when we lower the permissions of GITHUB_TOKEN on an org level.
