### PR TITLE
Bump calico 3.17 to 3.20 - drop support for k8s 1.16

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -31,16 +31,13 @@ jobs:
             helm-version: ""
           - k3s-version: ""
             k3s-channel: stable
-            helm-version: v3.4.2
+            helm-version: v3.6.3
           - k3s-version: ""
             k3s-channel: v1.18
             helm-version: v3.3.4
           - k3s-version: v1.17.13+k3s1
             k3s-channel: ""
             helm-version: v3.2.4
-          - k3s-version: ""
-            k3s-channel: v1.16
-            helm-version: v3.1.3
     steps:
       - uses: actions/checkout@v2
       - name: Local action
@@ -99,10 +96,7 @@ jobs:
           kubectl get deploy,daemonset,pods --all-namespaces
           # These options should be enabled
           kubectl get --namespace kube-system deploy metrics-server
-          # Problem with 1.16, ignore since it'll be dropped soon
-          if [[ "${{ matrix.k3s-version }}${{ matrix.k3s-channel }}" != v1.16* ]]; then
-              kubectl get --namespace kube-system deploy traefik
-          fi
+          kubectl get --namespace kube-system deploy traefik
 
       - name: Helm
         run: |

--- a/action.yml
+++ b/action.yml
@@ -80,8 +80,6 @@ runs:
     #
     #       ref: https://github.com/rancher/k3s/issues/947#issuecomment-627641541
     #
-    # NOTE: k3s 1.16 and older needed a flag named --no-deploy instead of
-    #       --disable.
     - name: Validate input
       run: |
         if [[ -n "${{ inputs.k3s-version }}" && -n "${{ inputs.k3s-channel }}" ]]; then
@@ -92,16 +90,11 @@ runs:
 
     - name: Setup k3s ${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
       run: |
-        if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.16* ]]; then
-          k3s_disable_command=--no-deploy
-        else
-          k3s_disable_command=--disable
-        fi
         if [[ "${{ inputs.metrics-enabled }}" != true ]]; then
-          k3s_disable_metrics="${k3s_disable_command} metrics-server"
+          k3s_disable_metrics="--disable metrics-server"
         fi
         if [[ "${{ inputs.traefik-enabled }}" != true ]]; then
-          k3s_disable_traefik="${k3s_disable_command} traefik"
+          k3s_disable_traefik="--disable traefik"
         fi
         if [[ "${{ inputs.docker-enabled }}" == true ]]; then
           k3s_docker=--docker
@@ -176,8 +169,7 @@ runs:
         if [[ "${{ inputs.metrics-enabled }}" == true ]]; then
           kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
         fi
-        # Problem with 1.16, ignore since it'll be dropped soon
-        if [[ "${{ inputs.traefik-enabled }}" == true && "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" != v1.16* ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" == true ]]; then
           kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
         fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -137,7 +137,7 @@ runs:
     #
     - name: Setup calico
       run: |
-        curl -sfL --output /tmp/calico.yaml https://docs.projectcalico.org/v3.17/manifests/calico.yaml
+        curl -sfL --output /tmp/calico.yaml https://docs.projectcalico.org/v3.20/manifests/calico.yaml
         cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\


### PR DESCRIPTION
Just motivated by routine maintenance and to verify for myself that 3.17 and 3.20 are both functional with this kind of configuration and startup of k3s.

---

Breaking change, k8s 1.16 isn't supported any more.