### PR TITLE
Fix failing traefik install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -170,6 +170,11 @@ runs:
           kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
         fi
         if [[ "${{ inputs.traefik-enabled }}" == true ]]; then
+          # NOTE: Different versions of k3s install traefik in different ways,
+          #       by waiting for these jobs if they exist, we will be fine no
+          #       matter what.
+          kubectl wait --for=condition=complete --timeout=300s job/helm-install-traefik-crd -n kube-system || true
+          kubectl wait --for=condition=complete --timeout=300s job/helm-install-traefik -n kube-system || true
           kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
         fi
       shell: bash


### PR DESCRIPTION
This action has started failing with modern k3s versions. I verified this by re-running our tests manually on current HEAD. I think it is related to how they install Traefik v2 and how they install traefik in general now - via a HelmChart CRD and a HelmChart controller that starts up Job resources to install the chart.

This is a quite simple and robust workaround I think.

Closes #32.

---

I have three PRs open that will cause merge conflicts with each other at the moment :scream:

- #34 --- This, a bugfix.
- #31 --- An enhancement.
- #29 --- A breaking maintenance change.

@manics I suggest this action plan:

1. Review -> merge this bugfix PR (#34).
2. Rebase #31 and resolve merge conflicts.
3. Review -> merge #31.
4. Add changelog for 1.2.0, and cut a release.
5. Rebase #29 and resolve merge conflicts.
6. Review -> merge #29.
7. Add changelog for 2.0.0, and cut a release.

What do you think?