### PR TITLE
ci: keep v1/v2/v3... tags updated instead of branches

### DIFF
--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -21,7 +21,3 @@ jobs:
       - uses: Actions-R-Us/actions-tagger@95c51c646e75db5c6b7d447e3087bcee58677341
         env:
           GITHUB_TOKEN: "${{ github.token }}"
-        with:
-          # By using branches as identifiers it is still possible to backtrack
-          # some patch, but not if we use tags.
-          prefer_branch_releases: true


### PR DESCRIPTION
Closes #44, describing the newly discovered and in my mind major drawback of having a v1 / v2 / v3 ... branch instead of a v1 / v2 / v3 ... tag

---

I've created tags `v1` and `v2` referencing the same things as the branches currently references. I suggest we delete the v1 and v2 branch following this is merged and agreed on, it seems confusing to have two separate git references referred to as v1 and v2, both a branch and a tag.