### PR TITLE
ci: use pre-commit.ci and dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,18 @@
+# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/action-k3s-helm/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/" # This should be / rather than .github/workflows
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"
+    labels:
+      - dependencies

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -6,19 +6,12 @@ on:
   pull_request:
   push:
     branches-ignore:
-      - "v*"
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags: ["**"]
   workflow_dispatch:
 
 jobs:
-  # https://github.com/pre-commit/action
-  pre-commit:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
-
   test_install_k3s:
     runs-on: ubuntu-latest
     name: Test K3s and Helm
@@ -164,7 +157,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Status matrix Test
     needs:
-      - pre-commit
       - test_install_k3s
       - test_install_k3s_options
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,24 @@
----
+# pre-commit is a tool to perform a predefined set of tasks manually and/or
+# automatically before git commits are made.
+#
+# Config reference: https://pre-commit.com/#pre-commit-configyaml---top-level
+#
+# Common tasks
+#
+# - Run on all files:   pre-commit run --all-files
+# - Register git hooks: pre-commit install --install-hooks
+#
 repos:
-  - repo: https://github.com/adrienverge/yamllint.git
+  # Autoformat: markdown, yaml
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.2
+    hooks:
+      - id: prettier
+
+  # Lint: yaml
+  - repo: https://github.com/adrienverge/yamllint
     rev: v1.26.3
     hooks:
       - id: yamllint
         args:
           - --config-data=relaxed
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2
-    hooks:
-      - id: prettier


### PR DESCRIPTION
The pre-commit hook we use can be run in pre-commit.ci without issues, lets do it!

Also, adding dependabot config to bump our github actions references in workflows.