### PR TITLE
Update cri-dockerd from 0.2.2 to 0.2.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
     - name: Setup cri-dockerd as a dockershim
       if: inputs.docker-enabled == 'true'
       env:
-        CRI_DOCKERD_VERSION: "0.2.2"
+        CRI_DOCKERD_VERSION: "0.2.3"
       run: |
         cd /tmp
 


### PR DESCRIPTION
No changes of importance it seems from https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.3, but I wanted to make sure we can rule out this is a problem when debugging another issue with k3s (#59)