### PR TITLE
Add input k3s-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ enforcement, and installs [Helm](https://helm.sh/) (3.1+).
 
 ## Optional input parameters
 
-- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.16 and later are supported. Defaults to the stable channel.
+- `k3s-channel`, `k3s-version`, or `k3s-commit`: Specify a K3s [release channel](https://update.k3s.io/v1-release/channels), [version](https://github.com/k3s-io/k3s/releases), or full length [commit](https://github.com/k3s-io/k3s/commits/HEAD). Versions 1.20 and later are supported. Defaults to the stable channel.
 - `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.1 and later are supported. Defaults to the latest version.
 - `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
 - `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.

--- a/action.yml
+++ b/action.yml
@@ -22,12 +22,16 @@ branding:
 # Thanks @consideratio !
 
 inputs:
-  k3s-version:
-    description: K3S version (https://github.com/rancher/k3s/releases)
-    required: false
-    default: ""
   k3s-channel:
     description: K3S channel (https://update.k3s.io/v1-release/channels)
+    required: false
+    default: ""
+  k3s-version:
+    description: K3S version (https://github.com/k3s-io/k3s/releases)
+    required: false
+    default: ""
+  k3s-commit:
+    description: K3S commit to install (https://github.com/k3s-io/k3s/releases)
     required: false
     default: ""
   helm-version:
@@ -78,13 +82,18 @@ runs:
     #       calico. --flannel-backend=none should not be passed if we don't want
     #       to install our own CNI.
     #
-    #       ref: https://github.com/rancher/k3s/issues/947#issuecomment-627641541
+    #       ref: https://github.com/k3s-io/k3s/issues/947#issuecomment-627641541
     #
     - name: Validate input
+      env:
+        INPUT_K3S_CHANNEL: "${{ inputs.k3s-channel }}"
+        INPUT_K3S_VERSION: "${{ inputs.k3s-version }}"
+        INPUT_K3S_COMMIT: "${{ inputs.k3s-commit }}"
       run: |
         echo "::group::Validate input"
-        if [[ -n "${{ inputs.k3s-version }}" && -n "${{ inputs.k3s-channel }}" ]]; then
-          echo "k3s-version and k3s-channel must not be specified simultaneously!"
+        VALIDATION_STRING="${INPUT_K3S_CHANNEL:+ok}${INPUT_K3S_VERSION:+ok}${INPUT_K3S_COMMIT:+ok}"
+        if [[ "${VALIDATION_STRING:-ok}" != "ok" ]]; then
+          echo "Specify at most one of the inputs: k3s-channel, k3s-version, and k3s-channel!"
           exit 1
         fi
         echo "::endgroup::"
@@ -129,7 +138,7 @@ runs:
         if [[ "${{ inputs.docker-enabled }}" == true ]]; then
           k3s_docker=--container-runtime-endpoint=/run/cri-dockerd.sock
         fi
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
+        curl -sfL https://get.k3s.io | INSTALL_K3S_COMMIT="${{ inputs.k3s-commit }}" INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
           ${k3s_disable_metrics} \
           ${k3s_disable_traefik} \
           --disable-network-policy \


### PR DESCRIPTION
I wanted to debug #59 and help k3s resolve an issue upstream, and as part of that try if a release candidate of k3s resolved the intermittent issue. To do that, I wanted to run tests in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2798 against the k3s release candidate version.

I turns out I was required to use INSTALL_K3S_COMMIT as an environment variable as it wasn't sufficient with INSTALL_K3S_VERSION or INSTALL_K3S_CHANNEL to test the release candidates of k3s 1.22, k3s 1.23, and k3s 1.24.

This would resolve that issue, and merging this should be followed by a 3.1.0 release of this action.

@manics what do you think?

---

UPDATE: It turns out (https://github.com/k3s-io/k3s/issues/5873), this wasn't needed for release candidates after all. So, this is solely for installing post-merge dev-releases in k3s. I figure this is a bit too niched as you can't even trial something before a PR is merged. I'll go for a close thinking its not worth the complexity addition.