### PR TITLE
Update cri-dockerd from 0.2.3 to 0.2.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
     - name: Setup cri-dockerd as a dockershim
       if: inputs.docker-enabled == 'true'
       env:
-        CRI_DOCKERD_VERSION: "0.2.3"
+        CRI_DOCKERD_VERSION: "0.2.5"
       run: |
         cd /tmp
 


### PR DESCRIPTION
I saw that 0.2.4 and 0.2.5 has been released, where 0.2.4 included a bugfix where irrelevant errors showed up in logs. This warning/error was something that distracted me before when trying to debug a k3s related intermittent error.

In 3.0.0 -> 3.0.1 we currently bump cri-dockerd from 0.2.2 to 0.2.3, I figure we can go from 0.2.2 directly to 0.2.5. I've read through the changelog in detail and I think this should be fine without any breaking changes.

## Related
- #65 
- #61 