### PR TITLE
fix: fail after 10 minutes (previously 5) as image pulling can take time

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -239,20 +239,20 @@ runs:
     - name: Wait for calico, coredns, metrics server, traefik
       run: |
         echo "::group::Wait for daemonset/calico-node"
-        kubectl rollout status --watch --timeout 300s daemonset/calico-node -n kube-system
+        kubectl rollout status --watch --timeout 600s daemonset/calico-node -n kube-system
         echo "::endgroup::"
 
         echo "::group::Wait for deployment/calico-kube-controllers"
-        kubectl rollout status --watch --timeout 300s deployment/calico-kube-controllers -n kube-system
+        kubectl rollout status --watch --timeout 600s deployment/calico-kube-controllers -n kube-system
         echo "::endgroup::"
 
         echo "::group::Wait for deployment/coredns"
-        kubectl rollout status --watch --timeout 300s deployment/coredns -n kube-system
+        kubectl rollout status --watch --timeout 600s deployment/coredns -n kube-system
         echo "::endgroup::"
 
         echo "::group::Wait for deployment/metrics-server"
         if [[ "${{ inputs.metrics-enabled }}" == true ]]; then
-          kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
+          kubectl rollout status --watch --timeout 600s deployment/metrics-server -n kube-system
         fi
         echo "::endgroup::"
 
@@ -261,9 +261,9 @@ runs:
           # NOTE: Different versions of k3s install traefik in different ways,
           #       by waiting for these jobs if they exist, we will be fine no
           #       matter what.
-          kubectl wait --for=condition=complete --timeout=300s job/helm-install-traefik-crd -n kube-system || true
-          kubectl wait --for=condition=complete --timeout=300s job/helm-install-traefik -n kube-system || true
-          kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
+          kubectl wait --for=condition=complete --timeout=600s job/helm-install-traefik-crd -n kube-system || true
+          kubectl wait --for=condition=complete --timeout=600s job/helm-install-traefik -n kube-system || true
+          kubectl rollout status --watch --timeout 600s deployment/traefik -n kube-system
         fi
         echo "::endgroup::"
       shell: bash


### PR DESCRIPTION
I think this closes #30. It seems that the images needed by daemonset/calico-node is sometimes not being pulled in 5 minutes time, and due to that causes this action to fail after ~5 minutes due to a timeout we have in this action hardcoded to 300s.

This PR increases that timeout to 600s to avoid this situation where the image pulling seem to work after being blocked by rate limiting or similar for a while.

![image](https://user-images.githubusercontent.com/3837114/185383040-deee2c81-5796-4044-b138-0b88e4084b4e.png)

![image](https://user-images.githubusercontent.com/3837114/185382942-e0eca1b6-fd8f-46d6-98b2-c0d5446d9932.png)