### PR TITLE
Calico 3.24.0 (3.23 manifest URL is broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## v3
 
+### v3.0.5 - 2022-08-21
+
+#### Bugs fixed
+
+- Calico 3.24.0 (3.23 manifest URL is broken) [#73](https://github.com/jupyterhub/action-k3s-helm/pull/73) ([@manics](https://github.com/manics))
+
 ### v3.0.4 - 2022-08-18
 
 #### Bugs fixed

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
-Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.17+) with
-[Calico](https://www.projectcalico.org/) (3.23) for
+Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.20+) with
+[Calico](https://www.projectcalico.org/) (3.24) for
 [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
-enforcement, and installs [Helm](https://helm.sh/) (3.1+).
+enforcement, and installs [Helm 3](https://helm.sh/) (3.1+).
 
 ## Optional input parameters
 
-- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.16 and later are supported. Defaults to the stable channel.
+- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.20 and later are supported. Defaults to the stable channel.
 - `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.1 and later are supported. Defaults to the latest version.
 - `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
 - `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.
@@ -20,10 +20,10 @@ enforcement, and installs [Helm](https://helm.sh/) (3.1+).
 
 - `kubeconfig`: The absolute path to the kubeconfig file (`$HOME/.kube/config`).
   The `KUBECONFIG` environment variable is also set by this action but may be removed in a future breaking release.
-- `k3s-version`: Installed k3s version, such as v1.20.0+k3s2
-- `k8s-version`: Installed k8s version, such as v1.20.0
-- `calico-version`: Installed calico version, such as v3.17.1
-- `helm-version`: Installed helm version, such as v3.4.2
+- `k3s-version`: Installed k3s version, such as v1.24.3+k3s1
+- `k8s-version`: Installed k8s version, such as v1.24.3
+- `calico-version`: Installed calico version, such as v3.24.0
+- `helm-version`: Installed helm version, such as v3.9.3
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -203,7 +203,7 @@ runs:
         if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.20* ]]; then
           curl -sfL --output /tmp/calico.yaml https://docs.projectcalico.org/v3.21/manifests/calico.yaml
         else
-          curl -sfL --output /tmp/calico.yaml https://projectcalico.docs.tigera.io/v3.23/manifests/calico.yaml
+          curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/calico.yaml
         fi
         cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\


### PR DESCRIPTION
The URL to download the 3.23 manifest from https://projectcalico.docs.tigera.io/v3.23/manifests/calico.yaml is broken (so the example work CI check will fail).

The current docs link to the 3.24.0 manifest on GitHub
https://projectcalico.docs.tigera.io/getting-started/kubernetes/self-managed-onprem/onpremises
which should be permanent