### PR TITLE
Update cri-dockerd from 0.2.5 to 0.2.6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
     - name: Setup cri-dockerd as a dockershim
       if: inputs.docker-enabled == 'true'
       env:
-        CRI_DOCKERD_VERSION: "0.2.5"
+        CRI_DOCKERD_VERSION: "0.2.6"
       run: |
         cd /tmp
 


### PR DESCRIPTION
Related changelog https://github.com/Mirantis/cri-dockerd/releases/tag/v0.2.6