### PR TITLE
Update cri-dockerd from 0.2.6 to 0.3.0 (only for k3s 1.24+) - now k3s 1.26 is supported

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,7 @@ runs:
         cd /tmp
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
+        chmod +x cri-dockerd
         sudo mv cri-dockerd /usr/bin/
 
         wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket

--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,8 @@ runs:
         sudo systemctl daemon-reload
         sudo systemctl enable cri-docker.service
         sudo systemctl enable --now cri-docker.socket
+
+        cri-dockerd --buildinfo
         echo "::endgroup::"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -97,8 +97,10 @@ runs:
     - name: Setup cri-dockerd as a dockershim
       if: inputs.docker-enabled == 'true'
       env:
-        CRI_DOCKERD_VERSION: "0.2.6"
+        # https://github.com/Mirantis/cri-dockerd/tags
+        CRI_DOCKERD_VERSION: "0.3.0"
       run: |
+        echo "::group::Setup cri-dockerd v${CRI_DOCKERD_VERSION} as a dockershim"
         cd /tmp
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
@@ -115,6 +117,7 @@ runs:
         sudo systemctl daemon-reload
         sudo systemctl enable cri-docker.service
         sudo systemctl enable --now cri-docker.socket
+        echo "::endgroup::"
       shell: bash
 
     # NOTE: We apply a workaround as of version 3.0.1 by passing

--- a/action.yml
+++ b/action.yml
@@ -100,8 +100,15 @@ runs:
         # https://github.com/Mirantis/cri-dockerd/tags
         CRI_DOCKERD_VERSION: "0.3.0"
       run: |
-        echo "::group::Setup cri-dockerd v${CRI_DOCKERD_VERSION} as a dockershim"
+        echo "::group::Setup cri-dockerd as a dockershim"
         cd /tmp
+
+        # Keep using cri-dockerd version 0.2.6 for versions 1.20-1.23 as 0.3.0+
+        # doesn't support them any more.
+        v=${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
+        if [[ "$v" == v1.20* ]] || [[ "$v" == v1.21* ]] || [[ "$v" == v1.22* ]] || [[ "$v" == v1.23* ]]; then
+          CRI_DOCKERD_VERSION=0.2.6
+        fi
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
         chmod +x cri-dockerd

--- a/action.yml
+++ b/action.yml
@@ -104,15 +104,16 @@ runs:
         cd /tmp
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
         sudo mv cri-dockerd /usr/bin/
-        sudo mv cri-docker.socket /etc/systemd/system/
-        sudo mv cri-docker.service /etc/systemd/system/
 
-        sudo sed --in-place --expression \
+        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
+        sudo mv cri-docker.socket /etc/systemd/system/
+
+        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
+        sed --in-place --expression \
             's,--network-plugin=,--network-plugin=cni --cni-bin-dir=/opt/cni/bin --cni-cache-dir=/var/lib/cni/cache --cni-conf-dir=/etc/cni/net.d,' \
-            /etc/systemd/system/cri-docker.service
+            cri-docker.service
+        sudo mv cri-docker.service /etc/systemd/system/
 
         sudo systemctl daemon-reload
         sudo systemctl enable cri-docker.service


### PR DESCRIPTION
The cri-dockerd update only involves https://github.com/Mirantis/cri-dockerd/pull/139 according to the changelog (https://github.com/Mirantis/cri-dockerd/releases/tag/v0.3.0).

- This adds support for k3s 1.26. I ran into a hiccup because https://github.com/Mirantis/cri-dockerd/issues/140 and that the extracted binary wasn't granted +x permissions.