### PR TITLE
Add call to systemctl status and jounalctl on failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -267,3 +267,33 @@ runs:
         fi
         echo "::endgroup::"
       shell: bash
+
+    - name: Diagnose setup failure
+      if: failure()
+      run: |
+        echo "::group::Diagnose failure - systemctl status k3s.service"
+        systemctl status k3s.service || true
+        echo "::endgroup::"
+
+        echo "::group::Diagnose failure - journalctl -xu k3s.service"
+        journalctl --no-pager -xu k3s.service
+        echo "::endgroup::"
+
+        if [[ "${{ inputs.docker-enabled }}" == true ]]; then
+          echo "::group::Diagnose failure - systemctl status cri-docker.service"
+          systemctl status cri-docker.service || true
+          echo "::endgroup::"
+
+          echo "::group::Diagnose failure - journalctl -xu cri-docker.service"
+          journalctl --no-pager -xu cri-docker.service
+          echo "::endgroup::"
+
+          echo "::group::Diagnose failure - systemctl status cri-docker.socket"
+          systemctl status cri-docker.socket || true
+          echo "::endgroup::"
+
+          echo "::group::Diagnose failure - journalctl -xu cri-docker.socket"
+          journalctl --no-pager -xu cri-docker.socket
+          echo "::endgroup::"
+        fi
+      shell: bash


### PR DESCRIPTION
This could be part of the action itself, or only be emitted in the CI system testing this action. I've now added it to the action itself to show up if and only if something has failed in the action.

- Note that the current failures are caused by #85, but can now be used to help demonstrate that this works.
