### PR TITLE
Support only k8s 1.24+, helm 3.5+, calico 3.27.0 and rely on k3s bundled cri-dockerd

### DIFF
--- a/.github/workflows/readme_example.yml
+++ b/.github/workflows/readme_example.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   k8s-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # GitHub Action reference: https://github.com/jupyterhub/action-k3s-helm
       - name: Start a local k8s cluster
@@ -21,8 +21,8 @@ jobs:
           # - k3s versions at https://github.com/k3s-io/k3s/tags
           # - helm versions at https://github.com/helm/helm/tags
           k3s-channel: latest
-          # k3s-version: v1.22.2+k3s1
-          # helm-version: v3.7.0
+          # k3s-version: v1.29.0+k3s1
+          # helm-version: v3.13.0
 
       - name: Verify function of k8s, kubectl, and helm
         run: |

--- a/.github/workflows/release_updates.yml
+++ b/.github/workflows/release_updates.yml
@@ -15,9 +15,6 @@ jobs:
       contents: write
     steps:
       # Action reference: https://github.com/Actions-R-Us/actions-tagger
-      # NOTE: We pin a version not to have the source code (.ts files), but the
-      #       compiled source code (.js files). This git hash is what v2.0.1
-      #       referenced 30 December 2020.
-      - uses: Actions-R-Us/actions-tagger@330ddfac760021349fef7ff62b372f2f691c20fb
+      - uses: Actions-R-Us/actions-tagger@v2
         with:
           token: "${{ github.token }}"

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test_install_k3s:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test K3s and Helm
     strategy:
       fail-fast: false
@@ -47,14 +47,14 @@ jobs:
             traefik-enabled: "false"
             docker-enabled: "false"
 
-          - k3s-version: v1.20.15+k3s1
+          - k3s-version: v1.24.7+k3s1
             k3s-channel: ""
             helm-version: v3.5.0
             metrics-enabled: "true"
             traefik-enabled: "true"
             docker-enabled: "false"
 
-          - k3s-version: v1.20.15+k3s1
+          - k3s-version: v1.24.7+k3s1
             k3s-channel: ""
             helm-version: v3.5.0
             metrics-enabled: "false"

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
-Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.20+) with
-[Calico](https://www.projectcalico.org/) (3.24) for
+Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.24+) with
+[Calico](https://www.projectcalico.org/) (3.27.0) for
 [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
-enforcement, and installs [Helm 3](https://helm.sh/) (3.1+).
+enforcement, and installs [Helm 3](https://helm.sh/) (3.5+).
 
 ## Optional input parameters
 
-- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.20 and later are supported. Defaults to the stable channel.
+- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.24 and later are supported. Defaults to the stable channel.
 - `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.1 and later are supported. Defaults to the latest version.
 - `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
 - `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.
@@ -20,10 +20,10 @@ enforcement, and installs [Helm 3](https://helm.sh/) (3.1+).
 
 - `kubeconfig`: The absolute path to the kubeconfig file (`$HOME/.kube/config`).
   The `KUBECONFIG` environment variable is also set by this action but may be removed in a future breaking release.
-- `k3s-version`: Installed k3s version, such as v1.24.3+k3s1
-- `k8s-version`: Installed k8s version, such as v1.24.3
-- `calico-version`: Installed calico version, such as v3.24.0
-- `helm-version`: Installed helm version, such as v3.9.3
+- `k3s-version`: Installed k3s version, such as v1.29.0+k3s1
+- `k8s-version`: Installed k8s version, such as v1.29.0
+- `calico-version`: Installed calico version, such as v3.27.0
+- `helm-version`: Installed helm version, such as v3.13.0
 
 ## Example
 
@@ -37,7 +37,7 @@ on:
 
 jobs:
   k8s-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # GitHub Action reference: https://github.com/jupyterhub/action-k3s-helm
       - name: Start a local k8s cluster
@@ -48,8 +48,8 @@ jobs:
           # - k3s versions at https://github.com/k3s-io/k3s/tags
           # - helm versions at https://github.com/helm/helm/tags
           k3s-channel: latest
-          # k3s-version: v1.22.2+k3s1
-          # helm-version: v3.7.0
+          # k3s-version: v1.29.0+k3s1
+          # helm-version: v3.13.0
 
       - name: Verify function of k8s, kubectl, and helm
         run: |

--- a/action.yml
+++ b/action.yml
@@ -90,34 +90,6 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-    # NOTE: The sed substitution operation is to run cri-dockerd in a way that
-    #       makes it work with calico as a CNI. This was based on
-    #       https://github.com/Mirantis/cri-dockerd/issues/42.
-    #
-    - name: Setup cri-dockerd as a dockershim
-      if: inputs.docker-enabled == 'true'
-      env:
-        # https://github.com/Mirantis/cri-dockerd/tags
-        CRI_DOCKERD_VERSION: "0.3.9"
-      run: |
-        echo "::group::Setup cri-dockerd as a dockershim"
-        cd /tmp
-
-        wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
-        sudo mv cri-dockerd /usr/bin/
-
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
-        sudo mv cri-docker.{service,socket} /etc/systemd/system/
-
-        sudo systemctl daemon-reload
-        sudo systemctl enable cri-docker.service
-        sudo systemctl enable --now cri-docker.socket
-
-        cri-dockerd --buildinfo
-        echo "::endgroup::"
-      shell: bash
-
     # NOTE: We apply a workaround as of version 3.0.1 by passing
     #       --egress-selector-mode=disabled by default as not doing so following
     #       modern versions of k3s has led to issues with `kubectl exec` and
@@ -137,7 +109,7 @@ runs:
           k3s_disable_traefik="--disable traefik"
         fi
         if [[ "${{ inputs.docker-enabled }}" == true ]]; then
-          k3s_docker=--container-runtime-endpoint=/run/cri-dockerd.sock
+          k3s_docker=--docker
         fi
         # We want to provide a new default value for the --egress-selector-mode
         # flag to avoid an intermittent issue possibly not fully resolved:

--- a/action.yml
+++ b/action.yml
@@ -104,17 +104,11 @@ runs:
         cd /tmp
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
-        chmod +x cri-dockerd
         sudo mv cri-dockerd /usr/bin/
 
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
-        sudo mv cri-docker.socket /etc/systemd/system/
-
         wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
-        sed --in-place --expression \
-            's,--network-plugin=,--network-plugin=cni --cni-bin-dir=/opt/cni/bin --cni-cache-dir=/var/lib/cni/cache --cni-conf-dir=/etc/cni/net.d,' \
-            cri-docker.service
-        sudo mv cri-docker.service /etc/systemd/system/
+        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
+        sudo mv cri-docker.{service,socket} /etc/systemd/system/
 
         sudo systemctl daemon-reload
         sudo systemctl enable cri-docker.service

--- a/action.yml
+++ b/action.yml
@@ -56,16 +56,16 @@ outputs:
     description: Path to kubeconfig file
     value: ${{ steps.set-output.outputs.kubeconfig }}
   k3s-version:
-    description: "Installed k3s version, such as v1.20.0+k3s2"
+    description: "Installed k3s version, such as v1.29.0+k3s1"
     value: "${{ steps.set-output.outputs.k3s-version }}"
   k8s-version:
-    description: "Installed k8s version, such as v1.20.0"
+    description: "Installed k8s version, such as v1.29.0"
     value: "${{ steps.set-output.outputs.k8s-version }}"
   calico-version:
-    description: "Installed calico version, such as v3.20.2"
+    description: "Installed calico version, such as v3.27.0"
     value: "${{ steps.set-output.outputs.calico-version }}"
   helm-version:
-    description: "Installed helm version, such as v3.4.2"
+    description: "Installed helm version, such as v3.13.0"
     value: "${{ steps.set-output.outputs.helm-version }}"
 
 runs:
@@ -98,17 +98,10 @@ runs:
       if: inputs.docker-enabled == 'true'
       env:
         # https://github.com/Mirantis/cri-dockerd/tags
-        CRI_DOCKERD_VERSION: "0.3.0"
+        CRI_DOCKERD_VERSION: "0.3.9"
       run: |
         echo "::group::Setup cri-dockerd as a dockershim"
         cd /tmp
-
-        # Keep using cri-dockerd version 0.2.6 for versions 1.20-1.23 as 0.3.0+
-        # doesn't support them any more.
-        v=${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
-        if [[ "$v" == v1.20* ]] || [[ "$v" == v1.21* ]] || [[ "$v" == v1.22* ]] || [[ "$v" == v1.23* ]]; then
-          CRI_DOCKERD_VERSION=0.2.6
-        fi
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
         chmod +x cri-dockerd
@@ -153,30 +146,14 @@ runs:
           k3s_docker=--container-runtime-endpoint=/run/cri-dockerd.sock
         fi
         # We want to provide a new default value for the --egress-selector-mode
-        # flag to workaround the intermittent issue tracked here:
+        # flag to avoid an intermittent issue possibly not fully resolved:
         # https://github.com/k3s-io/k3s/issues/5633#issuecomment-1181424511.
         #
+        # Details about the option available at
+        # https://docs.k3s.io/installation/network-options#control-plane-egress-selector-configuration.
+        #
         if [[ "${{ inputs.extra-setup-args }}" != *--egress-selector-mode* ]]; then
-          # We check for k3s versions 1.22.10+, 1.23.7+, or 1.24.1+ or more
-          # recent where we know the --egress-selector-mode flag is defined.
-          # This includes when the version isn't specified or is specified as
-          # latest or stable.
-          #
-          # The verlte function was taken from this stackoverflow post:
-          # https://stackoverflow.com/a/4024263/2220152
-          #
-          verlte() {
-            [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-          }
-          # If a k3s channel is specified we append a patch version of 99 to it
-          # to ensure our verlte comparisons below functions as intended.
-          #
-          c=${{ inputs.k3s-channel }}
-          c=${c:+$c.99}
-          v=${{ inputs.k3s-version }}${c}
-          if ([[ "$v" != v* ]]) || ([[ "$v" == v1.22.* ]] && verlte "v1.22.10" "$v") || ([[ "$v" == v1.23.* ]] && verlte "v1.23.7" "$v") || (verlte "v1.24.1" "$v"); then
-            default_extra_setup_args=--egress-selector-mode=disabled
-          fi
+          default_extra_setup_args=--egress-selector-mode=disabled
         fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
           ${k3s_disable_metrics} \
@@ -214,11 +191,7 @@ runs:
     - name: Setup calico
       run: |
         echo "::group::Setup calico"
-        if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.20* ]]; then
-          curl -sfL --output /tmp/calico.yaml https://docs.projectcalico.org/v3.21/manifests/calico.yaml
-        else
-          curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
-        fi
+        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
         cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\


### PR DESCRIPTION
## Changes

- Start relying on k3s to install cri-dockerd again (requires k3s 1.24+)
- Cleanup logic specific to older k3s versions
- Update calico from 3.24.5 to 3.27.0

### Related

- Closes #94