### PR TITLE
docs: make helm 3.5 be documented as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.20+) with
 [Calico](https://www.projectcalico.org/) (3.24) for
 [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
-enforcement, and installs [Helm 3](https://helm.sh/) (3.1+).
+enforcement, and installs [Helm 3](https://helm.sh/) (3.5+).
 
 ## Optional input parameters
 


### PR DESCRIPTION
PR 2/5 from #93 that was broken apart

I can't recall why, but I think it is a constraint we have and we only test against 3.5.0 and latest helm.
