### PR TITLE
Drop support for setting up k3s 1.20 to 1.23, now only 1.24+

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -47,14 +47,14 @@ jobs:
             traefik-enabled: "false"
             docker-enabled: "false"
 
-          - k3s-version: v1.20.15+k3s1
+          - k3s-version: v1.24.7+k3s1
             k3s-channel: ""
             helm-version: v3.5.0
             metrics-enabled: "true"
             traefik-enabled: "true"
             docker-enabled: "false"
 
-          - k3s-version: v1.20.15+k3s1
+          - k3s-version: v1.24.7+k3s1
             k3s-channel: ""
             helm-version: v3.5.0
             metrics-enabled: "false"

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
-Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.20+) with
+Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.24+) with
 [Calico](https://www.projectcalico.org/) (3.24) for
 [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 enforcement, and installs [Helm 3](https://helm.sh/) (3.1+).
 
 ## Optional input parameters
 
-- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.20 and later are supported. Defaults to the stable channel.
+- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.24 and later are supported. Defaults to the stable channel.
 - `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.1 and later are supported. Defaults to the latest version.
 - `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
 - `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.
@@ -20,10 +20,10 @@ enforcement, and installs [Helm 3](https://helm.sh/) (3.1+).
 
 - `kubeconfig`: The absolute path to the kubeconfig file (`$HOME/.kube/config`).
   The `KUBECONFIG` environment variable is also set by this action but may be removed in a future breaking release.
-- `k3s-version`: Installed k3s version, such as v1.24.3+k3s1
-- `k8s-version`: Installed k8s version, such as v1.24.3
-- `calico-version`: Installed calico version, such as v3.24.0
-- `helm-version`: Installed helm version, such as v3.9.3
+- `k3s-version`: Installed k3s version, such as v1.29.0+k3s1
+- `k8s-version`: Installed k8s version, such as v1.29.0
+- `calico-version`: Installed calico version, such as v3.27.0
+- `helm-version`: Installed helm version, such as v3.13.0
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -103,13 +103,6 @@ runs:
         echo "::group::Setup cri-dockerd as a dockershim"
         cd /tmp
 
-        # Keep using cri-dockerd version 0.2.6 for versions 1.20-1.23 as 0.3.0+
-        # doesn't support them any more.
-        v=${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
-        if [[ "$v" == v1.20* ]] || [[ "$v" == v1.21* ]] || [[ "$v" == v1.22* ]] || [[ "$v" == v1.23* ]]; then
-          CRI_DOCKERD_VERSION=0.2.6
-        fi
-
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
         chmod +x cri-dockerd
         sudo mv cri-dockerd /usr/bin/
@@ -153,30 +146,14 @@ runs:
           k3s_docker=--container-runtime-endpoint=/run/cri-dockerd.sock
         fi
         # We want to provide a new default value for the --egress-selector-mode
-        # flag to workaround the intermittent issue tracked here:
+        # flag to avoid an intermittent issue possibly not fully resolved:
         # https://github.com/k3s-io/k3s/issues/5633#issuecomment-1181424511.
         #
+        # Details about the option available at
+        # https://docs.k3s.io/installation/network-options#control-plane-egress-selector-configuration.
+        #
         if [[ "${{ inputs.extra-setup-args }}" != *--egress-selector-mode* ]]; then
-          # We check for k3s versions 1.22.10+, 1.23.7+, or 1.24.1+ or more
-          # recent where we know the --egress-selector-mode flag is defined.
-          # This includes when the version isn't specified or is specified as
-          # latest or stable.
-          #
-          # The verlte function was taken from this stackoverflow post:
-          # https://stackoverflow.com/a/4024263/2220152
-          #
-          verlte() {
-            [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
-          }
-          # If a k3s channel is specified we append a patch version of 99 to it
-          # to ensure our verlte comparisons below functions as intended.
-          #
-          c=${{ inputs.k3s-channel }}
-          c=${c:+$c.99}
-          v=${{ inputs.k3s-version }}${c}
-          if ([[ "$v" != v* ]]) || ([[ "$v" == v1.22.* ]] && verlte "v1.22.10" "$v") || ([[ "$v" == v1.23.* ]] && verlte "v1.23.7" "$v") || (verlte "v1.24.1" "$v"); then
-            default_extra_setup_args=--egress-selector-mode=disabled
-          fi
+          default_extra_setup_args=--egress-selector-mode=disabled
         fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
           ${k3s_disable_metrics} \
@@ -214,11 +191,7 @@ runs:
     - name: Setup calico
       run: |
         echo "::group::Setup calico"
-        if [[ "${{ inputs.k3s-version }}${{ inputs.k3s-channel }}" == v1.20* ]]; then
-          curl -sfL --output /tmp/calico.yaml https://docs.projectcalico.org/v3.21/manifests/calico.yaml
-        else
-          curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
-        fi
+        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
         cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\


### PR DESCRIPTION
PR 3/5 from #93 that was broken apart.

By dropping support for setting up k3s 1.20 to 1.23, we can make notable simplifications to this action. If someone needs to test k8s 1.23 still, they can still fall back on v3 of this action - as we would now release v4 with this merged as breaking.

Maintaining support for k8s 1.23 still is quite extreme, as k8s 1.24 in end of january no longer supported by GKE, EKS, or AKS for example, and k8s 1.29 is out.