### PR TITLE
Update calico from 3.24.5 to 3.27.0 and cri-dockerd from 0.3.0 to 0.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
 Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.24+) with
-[Calico](https://www.projectcalico.org/) (3.24) for
+[Calico](https://www.projectcalico.org/) (3.27.0) for
 [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 enforcement, and installs [Helm 3](https://helm.sh/) (3.5+).
 

--- a/action.yml
+++ b/action.yml
@@ -104,17 +104,11 @@ runs:
         cd /tmp
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
-        chmod +x cri-dockerd
         sudo mv cri-dockerd /usr/bin/
 
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
-        sudo mv cri-docker.socket /etc/systemd/system/
-
         wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
-        sed --in-place --expression \
-            's,--network-plugin=,--network-plugin=cni --cni-bin-dir=/opt/cni/bin --cni-cache-dir=/var/lib/cni/cache --cni-conf-dir=/etc/cni/net.d,' \
-            cri-docker.service
-        sudo mv cri-docker.service /etc/systemd/system/
+        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
+        sudo mv cri-docker.{service,socket} /etc/systemd/system/
 
         sudo systemctl daemon-reload
         sudo systemctl enable cri-docker.service

--- a/action.yml
+++ b/action.yml
@@ -191,7 +191,7 @@ runs:
     - name: Setup calico
       run: |
         echo "::group::Setup calico"
-        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
+        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
         cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
       if: inputs.docker-enabled == 'true'
       env:
         # https://github.com/Mirantis/cri-dockerd/tags
-        CRI_DOCKERD_VERSION: "0.3.0"
+        CRI_DOCKERD_VERSION: "0.3.9"
       run: |
         echo "::group::Setup cri-dockerd as a dockershim"
         cd /tmp


### PR DESCRIPTION
PR 4/5 from #93 that was broken apart.
