### PR TITLE
Rely on k3s to provide cri-dockerd

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
 Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.24+) with
-[Calico](https://www.projectcalico.org/) (3.24) for
+[Calico](https://www.projectcalico.org/) (3.27.0) for
 [NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 enforcement, and installs [Helm 3](https://helm.sh/) (3.5+).
 

--- a/action.yml
+++ b/action.yml
@@ -90,34 +90,6 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-    # NOTE: The sed substitution operation is to run cri-dockerd in a way that
-    #       makes it work with calico as a CNI. This was based on
-    #       https://github.com/Mirantis/cri-dockerd/issues/42.
-    #
-    - name: Setup cri-dockerd as a dockershim
-      if: inputs.docker-enabled == 'true'
-      env:
-        # https://github.com/Mirantis/cri-dockerd/tags
-        CRI_DOCKERD_VERSION: "0.3.9"
-      run: |
-        echo "::group::Setup cri-dockerd as a dockershim"
-        cd /tmp
-
-        wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
-        sudo mv cri-dockerd /usr/bin/
-
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
-        sudo mv cri-docker.{service,socket} /etc/systemd/system/
-
-        sudo systemctl daemon-reload
-        sudo systemctl enable cri-docker.service
-        sudo systemctl enable --now cri-docker.socket
-
-        cri-dockerd --buildinfo
-        echo "::endgroup::"
-      shell: bash
-
     # NOTE: We apply a workaround as of version 3.0.1 by passing
     #       --egress-selector-mode=disabled by default as not doing so following
     #       modern versions of k3s has led to issues with `kubectl exec` and
@@ -137,7 +109,7 @@ runs:
           k3s_disable_traefik="--disable traefik"
         fi
         if [[ "${{ inputs.docker-enabled }}" == true ]]; then
-          k3s_docker=--container-runtime-endpoint=/run/cri-dockerd.sock
+          k3s_docker=--docker
         fi
         # We want to provide a new default value for the --egress-selector-mode
         # flag to avoid an intermittent issue possibly not fully resolved:

--- a/action.yml
+++ b/action.yml
@@ -104,17 +104,11 @@ runs:
         cd /tmp
 
         wget -qO- https://github.com/Mirantis/cri-dockerd/releases/download/v${CRI_DOCKERD_VERSION}/cri-dockerd-${CRI_DOCKERD_VERSION}.amd64.tgz | tar -xvz --strip-components=1
-        chmod +x cri-dockerd
         sudo mv cri-dockerd /usr/bin/
 
-        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
-        sudo mv cri-docker.socket /etc/systemd/system/
-
         wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.service
-        sed --in-place --expression \
-            's,--network-plugin=,--network-plugin=cni --cni-bin-dir=/opt/cni/bin --cni-cache-dir=/var/lib/cni/cache --cni-conf-dir=/etc/cni/net.d,' \
-            cri-docker.service
-        sudo mv cri-docker.service /etc/systemd/system/
+        wget -q https://raw.githubusercontent.com/Mirantis/cri-dockerd/v${CRI_DOCKERD_VERSION}/packaging/systemd/cri-docker.socket
+        sudo mv cri-docker.{service,socket} /etc/systemd/system/
 
         sudo systemctl daemon-reload
         sudo systemctl enable cri-docker.service

--- a/action.yml
+++ b/action.yml
@@ -191,7 +191,7 @@ runs:
     - name: Setup calico
       run: |
         echo "::group::Setup calico"
-        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/calico.yaml
+        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
         cat /tmp/calico.yaml \
           | sed '/"type": "calico"/a\
             "container_settings": {\

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
       if: inputs.docker-enabled == 'true'
       env:
         # https://github.com/Mirantis/cri-dockerd/tags
-        CRI_DOCKERD_VERSION: "0.3.0"
+        CRI_DOCKERD_VERSION: "0.3.9"
       run: |
         echo "::group::Setup cri-dockerd as a dockershim"
         cd /tmp


### PR DESCRIPTION
PR 5/5 from #93 that was broken apart.

k3s 1.24+ bundles with cri-dockerd, so we can rely on k3s to provide it now that we constrain this action to k8s 1.24+.

Currently based on #106 to avoid conflicts, but once that is merged this can be closed/reopened to inspect the only change this PR includes: [9dc56f1](https://github.com/jupyterhub/action-k3s-helm/pull/107/commits/9dc56f110861d32dddf927be84d7e0f97f2430a4).