### PR TITLE
test: nginx 1.27.3

### DIFF
--- a/test-netpol-enforcement/Chart.yaml
+++ b/test-netpol-enforcement/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: test-netpol-enforcement
 version: 0.1.0
-appVersion: 1.16.0
+appVersion: 1.27.3


### PR DESCRIPTION
This updated image is useful for testing IPv6. The healthcheck in the current old image fails with IPv6.
