### PR TITLE
Update Calico to 3.31.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ outputs:
     description: "Installed k8s version, such as v1.29.0"
     value: "${{ steps.set-output.outputs.k8s-version }}"
   calico-version:
-    description: "Installed calico version, such as v3.28.1"
+    description: "Installed calico version, such as v3.31.4"
     value: "${{ steps.set-output.outputs.calico-version }}"
   helm-version:
     description: "Installed helm version, such as v3.13.0"
@@ -153,8 +153,9 @@ runs:
     - name: Setup calico
       run: |
         echo "::group::Setup calico"
+        CALICO_VERSION=v3.31.4
         # Download calico.yaml k8s and split into separate manifests
-        curl -sfL --output /tmp/calico.yaml https://raw.githubusercontent.com/projectcalico/calico/v3.28.1/manifests/calico.yaml
+        curl -sfL --output /tmp/calico.yaml "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
         mkdir calico
         cd calico
         yq -s '"\(.kind)-\(.metadata.name).yaml"' /tmp/calico.yaml


### PR DESCRIPTION
Release notes:
- 3.29 https://github.com/projectcalico/calico/tree/v3.29.7/release-notes
- 3.30 https://github.com/projectcalico/calico/tree/release-v3.30/release-notes
- 3.31 https://github.com/projectcalico/calico/tree/release-v3.31/release-notes