### PR TITLE
Remove possibly previously created calico directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -156,6 +156,7 @@ runs:
         CALICO_VERSION=v3.31.4
         # Download calico.yaml k8s and split into separate manifests
         curl -sfL --output /tmp/calico.yaml "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
+        rm -fr calico
         mkdir calico
         cd calico
         yq -s '"\(.kind)-\(.metadata.name).yaml"' /tmp/calico.yaml


### PR DESCRIPTION
If a previous run has created the `calico` directory, current run fails.

This PR makes sure the directory is deleted