### PR TITLE
Add Cilium CNI support inputs

### DIFF
--- a/.github/workflows/readme_example.yml
+++ b/.github/workflows/readme_example.yml
@@ -21,7 +21,7 @@ jobs:
           # - k3s versions at https://github.com/k3s-io/k3s/tags
           # - helm versions at https://github.com/helm/helm/tags
           k3s-channel: latest
-          # k3s-version: v1.29.0+k3s1
+          # k3s-version: v1.32.13+k3s1
           # helm-version: v3.13.0
 
       - name: Verify function of k8s, kubectl, and helm

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -19,54 +19,71 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - k3s-version: ""
+          - name: cilium-minimal
+            k3s-version: ""
+            k3s-channel: stable
+            helm-version: ""
+            cni-provider: cilium
+            cri-runtime: containerd
+            loadbalancer-service-support: "false"
+            gateway-api-support: "false"
+            ingress-support: "false"
+            resource-metrics-support: "false"
+
+          - name: cilium-maximal
+            k3s-version: ""
             k3s-channel: latest
             helm-version: ""
-            metrics-enabled: "true"
-            traefik-enabled: "true"
-            docker-enabled: "false"
+            cni-provider: cilium
+            cri-runtime: containerd
+            loadbalancer-service-support: "true"
+            gateway-api-support: "true"
+            ingress-support: "true"
+            resource-metrics-support: "true"
 
-          - k3s-version: ""
+          - name: cilium-maximal-oldest-k3s
+            k3s-version: v1.32.13+k3s1
+            k3s-channel: ""
+            helm-version: v3.5.0
+            cni-provider: calico
+            cri-runtime: docker
+            loadbalancer-service-support: "true"
+            gateway-api-support: "true"
+            ingress-support: "true"
+            resource-metrics-support: "true"
+
+          - name: calico-minimal
+            k3s-version: ""
+            k3s-channel: stable
+            helm-version: ""
+            cni-provider: calico
+            cri-runtime: containerd
+            loadbalancer-service-support: "false"
+            gateway-api-support: "false"
+            ingress-support: "false"
+            resource-metrics-support: "false"
+
+          - name: calico-maximal
+            k3s-version: ""
             k3s-channel: latest
             helm-version: "v4.0.5"
-            metrics-enabled: "true"
-            traefik-enabled: "true"
-            docker-enabled: "false"
+            cni-provider: calico
+            cri-runtime: docker
+            loadbalancer-service-support: "true"
+            gateway-api-support: "false"
+            ingress-support: "true"
+            resource-metrics-support: "true"
 
-          - k3s-version: ""
-            k3s-channel: latest
-            helm-version: ""
-            metrics-enabled: "false"
-            traefik-enabled: "false"
-            docker-enabled: "true"
-
-          - k3s-version: ""
-            k3s-channel: latest
-            helm-version: ""
-            metrics-enabled: "true"
-            traefik-enabled: "true"
-            docker-enabled: "true"
-
-          - k3s-version: ""
-            k3s-channel: latest
-            helm-version: ""
-            metrics-enabled: "false"
-            traefik-enabled: "false"
-            docker-enabled: "false"
-
-          - k3s-version: v1.24.7+k3s1
+          - name: calico-maximal-oldest-k3s
+            k3s-version: v1.32.13+k3s1
             k3s-channel: ""
             helm-version: v3.5.0
-            metrics-enabled: "true"
-            traefik-enabled: "true"
-            docker-enabled: "false"
-
-          - k3s-version: v1.24.7+k3s1
-            k3s-channel: ""
-            helm-version: v3.5.0
-            metrics-enabled: "false"
-            traefik-enabled: "false"
-            docker-enabled: "true"
+            cni-provider: calico
+            cri-runtime: docker
+            loadbalancer-service-support: "true"
+            gateway-api-support: "false"
+            ingress-support: "true"
+            resource-metrics-support: "true"
 
     steps:
       - uses: actions/checkout@v6
@@ -77,9 +94,12 @@ jobs:
           k3s-version: ${{ matrix.k3s-version }}
           k3s-channel: ${{ matrix.k3s-channel }}
           helm-version: ${{ matrix.helm-version }}
-          metrics-enabled: ${{ matrix.metrics-enabled }}
-          traefik-enabled: ${{ matrix.traefik-enabled }}
-          docker-enabled: ${{ matrix.docker-enabled }}
+          cni-provider: ${{ matrix.cni-provider }}
+          cri-runtime: ${{ matrix.cri-runtime }}
+          resource-metrics-support: ${{ matrix.resource-metrics-support }}
+          loadbalancer-service-support: ${{ matrix.loadbalancer-service-support }}
+          ingress-support: ${{ matrix.ingress-support }}
+          gateway-api-support: ${{ matrix.gateway-api-support }}
 
       - name: Verify action's outputs and env
         run: |
@@ -88,6 +108,7 @@ jobs:
           echo "k3s-version=${{ steps.k3s.outputs.k3s-version }}"
           echo "k8s-version=${{ steps.k3s.outputs.k8s-version }}"
           echo "calico-version=${{ steps.k3s.outputs.calico-version }}"
+          echo "cilium-version=${{ steps.k3s.outputs.cilium-version }}"
           echo "helm-version=${{ steps.k3s.outputs.helm-version }}"
           echo "---"
 
@@ -108,9 +129,25 @@ jobs:
               echo "k8s-version not set correctly as an action output"
               EXIT=1
           fi
-          if [[ "${{ steps.k3s.outputs.calico-version }}" != v* ]]; then
-              echo "calico-version not set correctly as an action output"
-              EXIT=1
+          if [[ "${{ matrix.cni-provider }}" == calico ]]; then
+              if [[ "${{ steps.k3s.outputs.calico-version }}" != v* ]]; then
+                  echo "calico-version not set correctly as an action output"
+                  EXIT=1
+              fi
+              if [[ -n "${{ steps.k3s.outputs.cilium-version }}" ]]; then
+                  echo "cilium-version should be empty when using calico"
+                  EXIT=1
+              fi
+          fi
+          if [[ "${{ matrix.cni-provider }}" == cilium ]]; then
+              if [[ -n "${{ steps.k3s.outputs.calico-version }}" ]]; then
+                  echo "calico-version should be empty when using cilium"
+                  EXIT=1
+              fi
+              if [[ "${{ steps.k3s.outputs.cilium-version }}" != v* ]]; then
+                  echo "cilium-version not set correctly as an action output"
+                  EXIT=1
+              fi
           fi
           if [[ "${{ steps.k3s.outputs.helm-version }}" != v* ]]; then
               echo "helm-version not set correctly as an action output"
@@ -124,6 +161,12 @@ jobs:
           kubectl version
           kubectl get storageclass
           kubectl get deploy,daemonset,pods --all-namespaces
+
+      - name: Information from cilium
+        if: matrix.cni-provider == 'cilium'
+        run: |
+          cilium version
+          cilium status
 
       - name: Information from docker
         run: |
@@ -140,30 +183,93 @@ jobs:
               exit 1
           fi
 
-      - name: Verify deploy/metrics-server based on metrics-enabled input
+      - name: Verify expected action setup
         run: |
-          kubectl get --namespace=kube-system deploy/metrics-server && enabled=true || enabled=false
-          if [[ "$enabled" != "${{ matrix.metrics-enabled }}" ]]; then
+          fail() {
+              echo "ERROR: $*"
+              exit 1
+          }
+
+          kubectl get --namespace=kube-system deploy/metrics-server > /dev/null 2>&1 && enabled=true || enabled=false
+          if [[ "$enabled" != "${{ matrix.resource-metrics-support }}" ]]; then
               echo "ERROR: deploy/metrics-server detected or not, which broke an assumption"
+              kubectl get --namespace=kube-system deploy/metrics-server || true
               exit 1
           fi
 
-      - name: Verify deploy/traefik based on traefik-enabled input
-        run: |
-          kubectl get --namespace=kube-system deploy/traefik && enabled=true || enabled=false
-          if [[ "$enabled" != "${{ matrix.traefik-enabled }}" ]]; then
+          kubectl get --namespace=kube-system deploy/traefik > /dev/null 2>&1 && enabled=true || enabled=false
+          if [[ "${{ matrix.cni-provider }}" == calico ]]; then
+              expected="${{ matrix.ingress-support }}"
+          else
+              expected=false
+          fi
+          if [[ "$enabled" != "$expected" ]]; then
               echo "ERROR: deploy/traefik detected or not, which broke an assumption"
+              kubectl get --namespace=kube-system deploy/traefik || true
               exit 1
           fi
 
-      # When using `docker-enabled: true` locally built images with docker
+          k3s_unit=$(sudo systemctl cat k3s | tr '\n' ' ')
+          if [[ "${{ matrix.loadbalancer-service-support }}" == true && "${{ matrix.cni-provider }}" == calico ]]; then
+              if grep -q -- "--disable.*servicelb" <<< "${k3s_unit}"; then
+                  sudo systemctl cat k3s
+                  fail "ServiceLB was disabled unexpectedly"
+              fi
+          else
+              if ! grep -q -- "--disable.*servicelb" <<< "${k3s_unit}"; then
+                  sudo systemctl cat k3s
+                  fail "ServiceLB was not disabled"
+              fi
+          fi
+
+          if [[ "${{ matrix.cni-provider }}" == calico ]]; then
+              if ! kubectl --namespace=kube-system get ds/calico-node > /dev/null 2>&1; then
+                  kubectl --namespace=kube-system get ds/calico-node || true
+                  fail "Calico node DaemonSet not detected"
+              fi
+              if ! kubectl --namespace=kube-system get deploy/calico-kube-controllers > /dev/null 2>&1; then
+                  kubectl --namespace=kube-system get deploy/calico-kube-controllers || true
+                  fail "Calico kube controllers Deployment not detected"
+              fi
+              if kubectl --namespace=kube-system get ds/cilium > /dev/null 2>&1; then
+                  kubectl --namespace=kube-system get ds/cilium
+                  fail "Cilium detected when using Calico"
+              fi
+          else
+              if ! kubectl --namespace=kube-system get ds/cilium > /dev/null 2>&1; then
+                  kubectl --namespace=kube-system get ds/cilium || true
+                  fail "Cilium DaemonSet not detected"
+              fi
+              if ! kubectl --namespace=kube-system get deploy/cilium-operator > /dev/null 2>&1; then
+                  kubectl --namespace=kube-system get deploy/cilium-operator || true
+                  fail "Cilium operator Deployment not detected"
+              fi
+              if kubectl --namespace=kube-system get ds/calico-node > /dev/null 2>&1; then
+                  kubectl --namespace=kube-system get ds/calico-node
+                  fail "Calico detected when using Cilium"
+              fi
+          fi
+
+          if [[ "${{ matrix.gateway-api-support }}" == true ]]; then
+              for crd in \
+                  gatewayclasses.gateway.networking.k8s.io \
+                  gateways.gateway.networking.k8s.io \
+                  httproutes.gateway.networking.k8s.io; do
+                  if ! kubectl get crd "${crd}" > /dev/null 2>&1; then
+                      kubectl get crd "${crd}" || true
+                      fail "Gateway API CRD ${crd} not detected"
+                  fi
+              done
+          fi
+
+      # When using `cri-runtime: docker` locally built images with docker
       # should be available without loading them for use by the k3s CRI.
       #
       - name: Verify local image is available for the k8s cluster
-        if: matrix.docker-enabled == 'true'
+        if: matrix.cri-runtime == 'docker'
         run: |
-          docker pull busybox:latest
-          docker tag busybox:latest jupyterhub/action-k3s-helm:available-locally
+          docker pull docker.io/busybox:latest
+          docker tag docker.io/busybox:latest jupyterhub/action-k3s-helm:available-locally
 
           cat <<EOF | kubectl apply -f -
           apiVersion: v1
@@ -179,11 +285,116 @@ jobs:
 
           kubectl wait pod image-available-locally --for condition=Ready --timeout=30s
 
-      - name: Install netpol enforcement test chart
-        run: helm install test-netpol-enforcement ./test-netpol-enforcement --wait
+      - name: Verify NetworkPolicy support
+        run: |
+          helm install test-netpol-enforcement ./test-netpol-enforcement --wait
+          helm test test-netpol-enforcement --logs
 
-      - name: Run netpol enforcement test chart's tests
-        run: helm test test-netpol-enforcement --logs
+      - name: Verify LoadBalancer Service support
+        if: matrix.loadbalancer-service-support == 'true'
+        run: |
+          curl_until_success() {
+              for _ in $(seq 1 60); do
+                  if output="$(curl --connect-timeout 2 --max-time 5 -fsS "$@" 2>&1)"; then
+                      echo "${output}"
+                      return 0
+                  fi
+                  sleep 2
+              done
+              echo "${output}"
+              return 1
+          }
+
+          helm install test-loadbalancer-service-support ./test-loadbalancer-service-support --wait
+          kubectl rollout status --watch deploy/loadbalancer-service-smoke
+          kubectl get svc/loadbalancer-service-smoke
+
+          if [[ "${{ matrix.cni-provider }}" == calico ]]; then
+              node_ip="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+              test_url="http://${node_ip}:8081"
+          else
+              lb_ip="$(kubectl get svc/loadbalancer-service-smoke -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+              test_url="http://${lb_ip}:8081"
+          fi
+
+          curl_until_success "${test_url}"
+
+      - name: Verify Gateway API support
+        if: matrix.gateway-api-support == 'true'
+        run: |
+          report_gateway_api_resources() {
+              kubectl get gateway/gateway-smoke -o yaml || true
+              kubectl get httproute/gateway-smoke -o yaml || true
+              kubectl get gatewayclass cilium -o yaml || true
+              kubectl get svc cilium-gateway-gateway-smoke -o yaml || true
+              kubectl logs --all-containers -n kube-system deploy/cilium-operator || true
+          }
+
+          trap 'status=$?; if [[ "${status}" != 0 ]]; then report_gateway_api_resources; fi; exit "${status}"' EXIT
+
+          helm_install_args=()
+          if [[ "${{ matrix.loadbalancer-service-support }}" != true ]]; then
+              node_ip="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+              helm_install_args+=(--set "test.url=http://${node_ip}:8080")
+          fi
+          helm install test-gateway-api ./test-gateway-api "${helm_install_args[@]}"
+          kubectl rollout status --watch deploy/gateway-smoke
+          kubectl wait gateway/gateway-smoke --for=condition=Accepted
+          kubectl get gateway/gateway-smoke
+          kubectl get httproute/gateway-smoke
+          kubectl get gatewayclass cilium
+          if [[ "${{ matrix.loadbalancer-service-support }}" == true ]]; then
+              kubectl get svc cilium-gateway-gateway-smoke
+          fi
+          helm test test-gateway-api --logs
+
+      - name: Verify Ingress support
+        if: matrix.ingress-support == 'true'
+        run: |
+          curl_until_success() {
+              for _ in $(seq 1 60); do
+                  if output="$(curl --connect-timeout 2 --max-time 5 -fsS "$@" 2>&1)"; then
+                      echo "${output}"
+                      return 0
+                  fi
+                  sleep 2
+              done
+              echo "${output}"
+              return 1
+          }
+
+          helm install test-ingress-support ./test-ingress-support --wait
+          kubectl rollout status --watch deploy/ingress-smoke
+          kubectl get ingress/ingress-smoke
+          if [[ "${{ matrix.cni-provider }}" == calico ]]; then
+              kubectl run test-ingress-support \
+                  --image=docker.io/curlimages/curl:latest \
+                  --restart=Never \
+                  --attach \
+                  --rm \
+                  --command -- curl -fsS -H "Host: ingress-smoke.local" \
+                      http://traefik.kube-system.svc.cluster.local
+          elif [[ "${{ matrix.loadbalancer-service-support }}" == true ]]; then
+              kubectl get svc/cilium-ingress --namespace=kube-system
+              lb_ip="$(kubectl get svc/cilium-ingress --namespace=kube-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
+              curl_until_success -H "Host: ingress-smoke.local" "http://${lb_ip}"
+          else
+              node_ip="$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+              curl_until_success -H "Host: ingress-smoke.local" "http://${node_ip}:8082"
+          fi
+
+      - name: Verify resource metrics support
+        if: matrix.resource-metrics-support == 'true'
+        run: |
+          for _ in $(seq 1 24); do
+              if kubectl top nodes; then
+                  kubectl top pods --all-namespaces
+                  exit 0
+              fi
+              sleep 5
+          done
+          echo "Timed out waiting for resource metrics"
+          exit 1
 
       # ref: https://github.com/jupyterhub/action-k8s-namespace-report
       - name: Kubernetes namespace report (kube-system)
@@ -194,6 +405,8 @@ jobs:
           important-workloads: >
             ds/calico-node
             deploy/calico-kube-controllers
+            ds/cilium
+            deploy/cilium-operator
             deploy/metrics-server
             deploy/traefik
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## Unreleased
+
+#### Breaking Changes
+
+- Add `cni-provider`, defaulting to `cilium`. This changes the default CNI from
+  the action's previous Calico-only behavior to Cilium.
+- Replace `docker-enabled` with `cri-runtime`; use `cri-runtime: docker` to
+  make k3s use the host Docker daemon through cri-dockerd.
+- Rename `metrics-enabled` to `resource-metrics-support`, and change the
+  default from `true` to `false`.
+- Rename `traefik-enabled` to `ingress-support`; Calico uses k3s Traefik and
+  Cilium uses Cilium Ingress. The default changes from `true` to `false`.
+- Add `loadbalancer-service-support`, defaulting to `false`; users must opt in
+  to support for Service resources of type `LoadBalancer`.
+- Add `gateway-api-support`, defaulting to `false`; this is only supported with
+  `cni-provider: cilium`.
+- Gateway API support installs the Gateway API 1.4.1 standard CRDs and the
+  experimental `TLSRoute` CRD required by Cilium 1.19.3.
+- Cilium Ingress and Gateway API use Cilium host-network mode when
+  `loadbalancer-service-support` is `false`.
+- Add Cilium support and a new `cilium-version` output. Existing
+  `calico-version` remains, and is empty when Cilium is selected.
+- With `cni-provider: cilium`, k3s kube-proxy is disabled and Cilium is
+  installed with kube-proxy replacement.
+
 ## v4
 
 ### v4.1.0 - 2026-03-13

--- a/README.md
+++ b/README.md
@@ -1,29 +1,38 @@
-# GitHub Action: Install K3s, Calico and Helm
+# GitHub Action: Install K3s, Calico or Cilium and Helm
 
 [![GitHub Action badge](https://github.com/jupyterhub/action-k3s-helm/workflows/Test/badge.svg)](https://github.com/jupyterhub/action-k3s-helm/actions)
 
-Creates a Kubernetes cluster using [K3s](https://k3s.io/) (1.24+) with
-[Calico](https://www.projectcalico.org/) (3.27.0) for
-[NetworkPolicy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
-enforcement, and installs [Helm 3/4](https://helm.sh/) (3.5+) (defaults to 3).
+Creates a Kubernetes cluster using [K3s] (1.32+) with [Cilium] (1.19.3, with
+Gateway API CRDs 1.4.1) or [Calico] (3.31.4) for [NetworkPolicy] enforcement,
+and installs [Helm] (3.5+).
+
+[k3s]: https://k3s.io/
+[cilium]: https://cilium.io/
+[calico]: https://www.projectcalico.org/
+[networkpolicy]: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+[helm]: https://helm.sh/
 
 ## Optional input parameters
 
-- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.24 and later are supported. Defaults to the stable channel.
-- `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.1 and later are supported. Defaults to the latest version.
-- `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
-- `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.
-- `docker-enabled`: Enable K3s to use the Docker daemon, `true` or `false` (default).
+- `k3s-version` or `k3s-channel`: Specify a K3s [version](https://github.com/rancher/k3s/releases) or [release channel](https://update.k3s.io/v1-release/channels). Versions 1.32 and later are supported. Defaults to the stable channel.
+- `helm-version`: Specify a Helm [version](https://github.com/helm/helm/releases). Versions 3.5 and later are supported. Defaults to the latest version.
+- `cni-provider`: CNI provider to install for NetworkPolicy support, `cilium` (default) or `calico`.
+- `cri-runtime`: Container runtime for k3s, `containerd` (default) or `docker`. `docker` configures k3s with `--docker`, using the host Docker daemon through cri-dockerd.
+- `resource-metrics-support`: Enable Kubernetes resource metrics support by installing k3s metrics-server, `true` or `false` (default).
+- `loadbalancer-service-support`: Enable support for Kubernetes Services with `type: LoadBalancer`, `true` or `false` (default). With `cni-provider: calico` this uses k3s ServiceLB; with `cni-provider: cilium` this uses Cilium Node IPAM.
+- `ingress-support`: Enable ingress support, `true` or `false` (default). With `cni-provider: calico` this enables k3s Traefik; with `cni-provider: cilium` this enables Cilium Ingress.
+- `gateway-api-support`: Enable Gateway API support with Cilium, `true` or `false` (default). This requires `cni-provider: cilium`.
 - `extra-setup-args`: Extra arguments passed unquoted to the K3s setup script, use this if you require advanced customisation.
 
 ## Outputs
 
 - `kubeconfig`: The absolute path to the kubeconfig file (`$HOME/.kube/config`).
-  The `KUBECONFIG` environment variable is also set by this action but may be removed in a future breaking release.
-- `k3s-version`: Installed k3s version, such as v1.29.0+k3s1
-- `k8s-version`: Installed k8s version, such as v1.29.0
-- `calico-version`: Installed calico version, such as v3.27.0
-- `helm-version`: Installed helm version, such as v3.13.0 or v4.0.5. Defaults to latest v3.x
+  The `KUBECONFIG` environment variable is also set by this action.
+- `k3s-version`: Installed k3s version, such as v1.32.13+k3s1
+- `k8s-version`: Installed k8s version, such as v1.32.13
+- `calico-version`: Installed calico version, such as v3.31.4, or empty if `cni-provider` is `cilium`
+- `cilium-version`: Installed cilium version, such as v1.19.3, or empty if `cni-provider` is `calico`
+- `helm-version`: Installed helm version, such as v3.13.0 or v4.0.5. Defaults to latest
 
 ## Example
 
@@ -37,7 +46,7 @@ on:
 
 jobs:
   k8s-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       # GitHub Action reference: https://github.com/jupyterhub/action-k3s-helm
       - name: Start a local k8s cluster
@@ -48,7 +57,7 @@ jobs:
           # - k3s versions at https://github.com/k3s-io/k3s/tags
           # - helm versions at https://github.com/helm/helm/tags
           k3s-channel: latest
-          # k3s-version: v1.29.0+k3s1
+          # k3s-version: v1.32.13+k3s1
           # helm-version: v3.13.0
 
       - name: Verify function of k8s, kubectl, and helm
@@ -69,9 +78,10 @@ This action aims to to provide an easy to use Kubernetes cluster with the follow
 
 - K3s
 - Helm 3+
-- Calico network provider that supports network policies
+- Cilium or Calico CNI provider that supports network policies
 
 A small number of features are configurable.
-All K3s defaults are kept except where they conflict with the deployment of Calico.
+K3s defaults are kept except where they conflict with the selected CNI provider
+or disabled optional support.
 Due to the difficulty in comprehensively testing this action the aim is to minimise the number of arguments.
 If you have an advanced use case hopefully `extra-setup-args` will be sufficient.

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@
 # Reference: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
 #
 ---
-name: K3S with Calico and Helm
+name: K3S with Calico or Cilium and Helm
 description: |
-  Install Kubernetes (K3S) and Helm 3.
-  Includes Calico network plugin for network policy support.
+  Install Kubernetes (K3S) and Helm.
+  Includes Calico or Cilium network plugin for network policy support.
 
 branding:
   icon: server
@@ -31,19 +31,31 @@ inputs:
     required: false
     default: ""
   helm-version:
-    description: Helm 3+ version (https://github.com/helm/helm/releases) (defaults to latest 3.x)
+    description: Helm version (https://github.com/helm/helm/releases) (defaults to latest, 3.5+ supported)
     required: false
     default: ""
-  metrics-enabled:
-    description: Enable or disable K3S metrics-server
+  cni-provider:
+    description: CNI provider to install, cilium or calico
     required: false
-    default: "true"
-  traefik-enabled:
-    description: Enable or disable K3S Traefik ingress
+    default: cilium
+  cri-runtime:
+    description: Container runtime for k3s, containerd or docker
     required: false
-    default: "true"
-  docker-enabled:
-    description: Enable K3s to use the Docker daemon
+    default: containerd
+  loadbalancer-service-support:
+    description: Enable LoadBalancer Service support; Calico uses k3s ServiceLB, Cilium uses Cilium Node IPAM
+    required: false
+    default: "false"
+  gateway-api-support:
+    description: Enable Gateway API support with Cilium (requires cni-provider set to cilium)
+    required: false
+    default: "false"
+  ingress-support:
+    description: Enable Ingress resource support using Cilium Ingress with Cilium or Traefik with Calico
+    required: false
+    default: "false"
+  resource-metrics-support:
+    description: Enable Kubernetes resource metrics (for `kubectl top ...`) support by installing k3s metrics-server
     required: false
     default: "false"
   extra-setup-args:
@@ -56,14 +68,17 @@ outputs:
     description: Path to kubeconfig file
     value: ${{ steps.set-output.outputs.kubeconfig }}
   k3s-version:
-    description: "Installed k3s version, such as v1.29.0+k3s1"
+    description: "Installed k3s version, such as v1.32.13+k3s1"
     value: "${{ steps.set-output.outputs.k3s-version }}"
   k8s-version:
-    description: "Installed k8s version, such as v1.29.0"
+    description: "Installed k8s version, such as v1.32.13"
     value: "${{ steps.set-output.outputs.k8s-version }}"
   calico-version:
     description: "Installed calico version, such as v3.31.4"
     value: "${{ steps.set-output.outputs.calico-version }}"
+  cilium-version:
+    description: "Installed cilium version, such as v1.19.3"
+    value: "${{ steps.set-output.outputs.cilium-version }}"
   helm-version:
     description: "Installed helm version, such as v3.13.0"
     value: "${{ steps.set-output.outputs.helm-version }}"
@@ -74,9 +89,9 @@ runs:
     # https://rancher.com/docs/k3s/latest/en/installation/install-options/how-to-flags/
     #
     # NOTE: k3s has a Network Policy controller called kube-router, but it is
-    #       not robust enough for use, so we disable it and install our own:
-    #       calico. --flannel-backend=none should not be passed if we don't want
-    #       to install our own CNI.
+    #       not robust enough for use, so we disable it and install our selected
+    #       CNI. --flannel-backend=none should not be passed if we don't want to
+    #       install our own CNI.
     #
     #       ref: https://github.com/rancher/k3s/issues/947#issuecomment-627641541
     #
@@ -87,28 +102,48 @@ runs:
           echo "k3s-version and k3s-channel must not be specified simultaneously!"
           exit 1
         fi
+        if [[ "${{ inputs.cni-provider }}" != calico && "${{ inputs.cni-provider }}" != cilium ]]; then
+          echo "cni-provider must be either calico or cilium!"
+          exit 1
+        fi
+        if [[ "${{ inputs.cri-runtime }}" != containerd && "${{ inputs.cri-runtime }}" != docker ]]; then
+          echo "cri-runtime must be either containerd or docker!"
+          exit 1
+        fi
+        for bool_input in \
+          resource-metrics-support="${{ inputs.resource-metrics-support }}" \
+          loadbalancer-service-support="${{ inputs.loadbalancer-service-support }}" \
+          ingress-support="${{ inputs.ingress-support }}" \
+          gateway-api-support="${{ inputs.gateway-api-support }}"
+        do
+          if [[ "${bool_input#*=}" != true && "${bool_input#*=}" != false ]]; then
+            echo "${bool_input%%=*} must be either true or false!"
+            exit 1
+          fi
+        done
+        if [[ "${{ inputs.gateway-api-support }}" == true && "${{ inputs.cni-provider }}" == calico ]]; then
+          echo "gateway-api-support is only supported with cni-provider: cilium!"
+          exit 1
+        fi
         echo "::endgroup::"
       shell: bash
 
-    # NOTE: We apply a workaround as of version 3.0.1 by passing
-    #       --egress-selector-mode=disabled by default as not doing so following
-    #       modern versions of k3s has led to issues with `kubectl exec` and
-    #       `kubectl logs`.
-    #
-    #       For more details, see
-    #       https://github.com/k3s-io/k3s/issues/5633
-    #       and https://github.com/jupyterhub/action-k3s-helm/issues/59.
-    #
     - name: Setup k3s ${{ inputs.k3s-version }}${{ inputs.k3s-channel }}
       run: |
         echo "::group::Setup k3s ${{ inputs.k3s-version }}${{ inputs.k3s-channel }}"
-        if [[ "${{ inputs.metrics-enabled }}" != true ]]; then
+        if [[ "${{ inputs.resource-metrics-support }}" != true ]]; then
           k3s_disable_metrics="--disable metrics-server"
         fi
-        if [[ "${{ inputs.traefik-enabled }}" != true ]]; then
+        if [[ "${{ inputs.loadbalancer-service-support }}" != true || "${{ inputs.cni-provider }}" == cilium ]]; then
+          k3s_disable_servicelb="--disable servicelb"
+        fi
+        if [[ "${{ inputs.ingress-support }}" != true || "${{ inputs.cni-provider }}" == cilium ]]; then
           k3s_disable_traefik="--disable traefik"
         fi
-        if [[ "${{ inputs.docker-enabled }}" == true ]]; then
+        if [[ "${{ inputs.cni-provider }}" == cilium ]]; then
+          k3s_disable_kube_proxy="--disable-kube-proxy"
+        fi
+        if [[ "${{ inputs.cri-runtime }}" == docker ]]; then
           k3s_docker=--docker
         fi
         # We want to provide a new default value for the --egress-selector-mode
@@ -124,6 +159,8 @@ runs:
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" INSTALL_K3S_CHANNEL="${{ inputs.k3s-channel }}" sh -s - \
           ${k3s_disable_metrics} \
           ${k3s_disable_traefik} \
+          ${k3s_disable_servicelb} \
+          ${k3s_disable_kube_proxy} \
           --disable-network-policy \
           --flannel-backend=none \
           ${k3s_docker} \
@@ -151,9 +188,11 @@ runs:
     # ref: https://rancher.com/docs/k3s/latest/en/installation/network-options/
     #
     - name: Setup calico
+      if: inputs.cni-provider == 'calico'
       run: |
         echo "::group::Setup calico"
         CALICO_VERSION=v3.31.4
+        echo "${CALICO_VERSION}" > /tmp/calico-version
         # Download calico.yaml k8s and split into separate manifests
         curl -sfL --output /tmp/calico.yaml "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
         rm -fr calico
@@ -175,14 +214,81 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-    # There will be some waiting for calico to make the k8s Nodes ready and for
-    # the k3s related pods to start and become ready, so there is time to
-    # install Helm at this point for example.
+    # Install cilium as a CNI to enforce our NetworkPolicies.
+    #
+    # ref: https://docs.cilium.io/en/stable/installation/k3s/
+    #
+    - name: Setup cilium
+      if: inputs.cni-provider == 'cilium'
+      run: |
+        echo "::group::Setup cilium"
+        CILIUM_VERSION=1.19.3
+        CILIUM_CLI_VERSION=v0.19.2
+        GATEWAY_API_VERSION=v1.4.1
+        CLI_ARCH=amd64
+        if [[ "$(uname -m)" == aarch64 ]]; then
+          CLI_ARCH=arm64
+        fi
+
+        for suffix in "" ".sha256sum"; do
+          curl -L --fail --retry 5 --retry-delay 2 --retry-all-errors --remote-name \
+            "https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz${suffix}"
+        done
+        sha256sum --check "cilium-linux-${CLI_ARCH}.tar.gz.sha256sum"
+        sudo tar xzvfC "cilium-linux-${CLI_ARCH}.tar.gz" /usr/local/bin
+        rm "cilium-linux-${CLI_ARCH}.tar.gz"{,.sha256sum}
+
+        if [[ "${{ inputs.gateway-api-support }}" == true ]]; then
+          for crd in gatewayclasses gateways httproutes referencegrants grpcroutes; do
+            kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard/gateway.networking.k8s.io_${crd}.yaml"
+          done
+          kubectl apply -f "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml"
+        fi
+
+        cilium_install_args=(
+          --version "${CILIUM_VERSION}"
+          --wait=false
+          --set=ipam.operator.clusterPoolIPv4PodCIDRList="10.42.0.0/16"
+          --set=kubeProxyReplacement=true
+          --set=k8sServiceHost=127.0.0.1
+          --set=k8sServicePort=6443
+        )
+        if [[ "${{ inputs.loadbalancer-service-support }}" == true ]]; then
+          cilium_install_args+=(
+            --set=nodeIPAM.enabled=true
+            --set=defaultLBServiceIPAM=nodeipam
+          )
+        fi
+        if [[ "${{ inputs.ingress-support }}" == true ]]; then
+          cilium_install_args+=(
+            --set=ingressController.enabled=true
+            --set=ingressController.default=true
+          )
+          if [[ "${{ inputs.loadbalancer-service-support }}" == true ]]; then
+            cilium_install_args+=(--set=ingressController.loadbalancerMode=shared)
+          else
+            cilium_install_args+=(--set=ingressController.hostNetwork.enabled=true)
+          fi
+        fi
+        if [[ "${{ inputs.gateway-api-support }}" == true ]]; then
+          cilium_install_args+=(--set=gatewayAPI.enabled=true)
+          if [[ "${{ inputs.loadbalancer-service-support }}" != true ]]; then
+            cilium_install_args+=(--set=gatewayAPI.hostNetwork.enabled=true)
+          fi
+        fi
+        cilium install "${cilium_install_args[@]}"
+        echo "v${CILIUM_VERSION}" > /tmp/cilium-version
+        echo "::endgroup::"
+      shell: bash
+
+    # There will be some waiting for calico/cilium to make the k8s Nodes ready
+    # and for the k3s related pods to start and become ready, so there is time
+    # now available to install Helm.
     - name: Setup Helm ${{ inputs.helm-version }}
       run: |
         HELM_VERSION="${{ inputs.helm-version }}"
         echo "::group::Setup Helm ${HELM_VERSION}"
-        if [[ "${HELM_VERSION}" == v4* ]]; then
+        if [[ -z "${HELM_VERSION}" || "${HELM_VERSION}" == v4* ]]; then
           HELM_INSTALL_SCRIPT=https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-4
         else
           HELM_INSTALL_SCRIPT=https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
@@ -198,39 +304,59 @@ runs:
         echo "kubeconfig=$HOME/.kube/config" >> $GITHUB_OUTPUT
         echo "k3s-version=$(k3s --version | grep --max-count=1 'k3s' | sed 's/.*\(v[0-9][^ ]*\).*/\1/')" >> $GITHUB_OUTPUT
         echo "k8s-version=$(k3s --version | grep --max-count=1 'k3s' | sed 's/.*\(v[0-9][^+]*\).*/\1/')" >> $GITHUB_OUTPUT
-        echo "calico-version=$(cat /tmp/calico.yaml | grep --max-count=1 'calico/cni:v' | sed 's/.*calico\/cni:\(.*\)/\1/')" >> $GITHUB_OUTPUT
+        if [[ "${{ inputs.cni-provider }}" == calico ]]; then
+          echo "calico-version=$(cat /tmp/calico-version)" >> $GITHUB_OUTPUT
+          echo "cilium-version=" >> $GITHUB_OUTPUT
+        else
+          echo "calico-version=" >> $GITHUB_OUTPUT
+          echo "cilium-version=$(cat /tmp/cilium-version)" >> $GITHUB_OUTPUT
+        fi
         echo "helm-version=$(helm version --short | sed 's/\([^+]*\).*/\1/')" >> $GITHUB_OUTPUT
         echo "::endgroup::"
       shell: bash
 
-    - name: Wait for calico, coredns, metrics server, traefik
+    - name: Wait for calico
+      if: inputs.cni-provider == 'calico'
       run: |
         echo "::group::Wait for daemonset/calico-node"
-        kubectl rollout status --watch --timeout=5m daemonset/calico-node -n kube-system
+        kubectl rollout status --watch --timeout=2m daemonset/calico-node -n kube-system
         echo "::endgroup::"
 
         echo "::group::Wait for deployment/calico-kube-controllers"
-        kubectl rollout status --watch --timeout=5m deployment/calico-kube-controllers -n kube-system
+        kubectl rollout status --watch --timeout=2m deployment/calico-kube-controllers -n kube-system
         echo "::endgroup::"
+      shell: bash
 
+    - name: Wait for cilium
+      if: inputs.cni-provider == 'cilium'
+      run: |
+        echo "::group::Wait for cilium"
+        if ! cilium status --wait; then
+          kubectl get pods,daemonset,deployment -n kube-system
+          kubectl describe pods -n kube-system -l k8s-app=cilium || true
+          kubectl describe pods -n kube-system -l io.cilium/app=operator || true
+          exit 1
+        fi
+        echo "::endgroup::"
+      shell: bash
+
+    - name: Wait for coredns, metrics server, traefik
+      run: |
         echo "::group::Wait for deployment/coredns"
-        kubectl rollout status --watch --timeout=5m deployment/coredns -n kube-system
+        kubectl rollout status --watch --timeout=2m deployment/coredns -n kube-system
         echo "::endgroup::"
 
-        echo "::group::Wait for deployment/metrics-server"
-        if [[ "${{ inputs.metrics-enabled }}" == true ]]; then
-          kubectl rollout status --watch --timeout=5m deployment/metrics-server -n kube-system
+        if [[ "${{ inputs.resource-metrics-support }}" == true ]]; then
+          echo "::group::Wait for deployment/metrics-server"
+          kubectl rollout status --watch --timeout=2m deployment/metrics-server -n kube-system
+          echo "::endgroup::"
         fi
-        echo "::endgroup::"
 
-        echo "::group::Wait for deployment/traefik"
-        if [[ "${{ inputs.traefik-enabled }}" == true ]]; then
-          # NOTE: Different versions of k3s install traefik in different ways,
-          #       by waiting for these jobs if they exist, we will be fine no
-          #       matter what.
-          kubectl wait --for=condition=complete --timeout=5m job/helm-install-traefik-crd -n kube-system || true
-          kubectl wait --for=condition=complete --timeout=5m job/helm-install-traefik -n kube-system || true
-          kubectl rollout status --watch --timeout=5m deployment/traefik -n kube-system
+        if [[ "${{ inputs.cni-provider }}" == calico && "${{ inputs.ingress-support }}" == true ]]; then
+          echo "::group::Wait for deployment/traefik"
+          kubectl wait --for=condition=complete --timeout=2m job/helm-install-traefik-crd -n kube-system || true
+          kubectl wait --for=condition=complete --timeout=2m job/helm-install-traefik -n kube-system || true
+          kubectl rollout status --watch --timeout=2m deployment/traefik -n kube-system
+          echo "::endgroup::"
         fi
-        echo "::endgroup::"
       shell: bash

--- a/test-gateway-api/Chart.yaml
+++ b/test-gateway-api/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
-name: test-netpol-enforcement
+name: test-gateway-api
 version: 0.1.0

--- a/test-gateway-api/templates/backend.yaml
+++ b/test-gateway-api/templates/backend.yaml
@@ -2,16 +2,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: protected-webserver
+  name: gateway-smoke
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: protected-webserver
+      app.kubernetes.io/name: gateway-smoke
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: protected-webserver
+        app.kubernetes.io/name: gateway-smoke
     spec:
       containers:
         - name: nginx
@@ -28,11 +28,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: protected-webserver
+  name: gateway-smoke
 spec:
-  type: ClusterIP
   selector:
-    app.kubernetes.io/name: protected-webserver
+    app.kubernetes.io/name: gateway-smoke
   ports:
     - port: 80
       targetPort: http

--- a/test-gateway-api/templates/gateway.yaml
+++ b/test-gateway-api/templates/gateway.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: gateway-smoke
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+      hostname: gateway-smoke.local
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: gateway-smoke
+spec:
+  parentRefs:
+    - name: gateway-smoke
+  hostnames:
+    - gateway-smoke.local
+  rules:
+    - backendRefs:
+        - name: gateway-smoke
+          port: 80

--- a/test-gateway-api/templates/tests/test-gateway-api.yaml
+++ b/test-gateway-api/templates/tests/test-gateway-api.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-gateway-api
+  annotations:
+    helm.sh/hook: test-success
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: docker.io/curlimages/curl:latest
+      command:
+        - sh
+        - -c
+        - |
+          for i in $(seq 1 60); do
+              if curl -fsS -H "Host: gateway-smoke.local" {{ required "test.url is required" .Values.test.url | quote }}; then
+                  exit 0
+              fi
+              sleep 2
+          done
+          exit 1

--- a/test-gateway-api/values.yaml
+++ b/test-gateway-api/values.yaml
@@ -1,0 +1,2 @@
+test:
+  url: http://cilium-gateway-gateway-smoke:8080

--- a/test-ingress-support/Chart.yaml
+++ b/test-ingress-support/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: test-ingress-support
+description: Test chart for verifying Kubernetes Ingress support.
+version: 0.1.0

--- a/test-ingress-support/templates/backend.yaml
+++ b/test-ingress-support/templates/backend.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-smoke
+  labels:
+    app.kubernetes.io/name: ingress-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-smoke
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-smoke
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginx:latest
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-smoke
+  labels:
+    app.kubernetes.io/name: ingress-smoke
+spec:
+  selector:
+    app.kubernetes.io/name: ingress-smoke
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/test-ingress-support/templates/ingress.yaml
+++ b/test-ingress-support/templates/ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-smoke
+  annotations:
+    ingress.cilium.io/host-listener-port: "8082"
+spec:
+  rules:
+    - host: ingress-smoke.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ingress-smoke
+                port:
+                  number: 80

--- a/test-loadbalancer-service-support/Chart.yaml
+++ b/test-loadbalancer-service-support/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: test-loadbalancer-service-support
+description: Test chart for verifying Kubernetes LoadBalancer Service support.
+version: 0.1.0

--- a/test-loadbalancer-service-support/templates/backend.yaml
+++ b/test-loadbalancer-service-support/templates/backend.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadbalancer-service-smoke
+  labels:
+    app.kubernetes.io/name: loadbalancer-service-smoke
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loadbalancer-service-smoke
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loadbalancer-service-smoke
+    spec:
+      containers:
+        - name: nginx
+          image: docker.io/nginx:latest
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loadbalancer-service-smoke
+  labels:
+    app.kubernetes.io/name: loadbalancer-service-smoke
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: loadbalancer-service-smoke
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 80

--- a/test-netpol-enforcement/templates/networkpolicy-block-egress.yaml
+++ b/test-netpol-enforcement/templates/networkpolicy-block-egress.yaml
@@ -1,8 +1,7 @@
 ---
-# Test egress CIDR policies: allow egress to private CIDRs (within cluster)
-# only. Pods labelled "egress-internal-only" should be able to connect to the
-# unprotected-webserver:80 service but not unprotected-webserver:81, nor
-# public internet webservers
+# Test egress policies. Pods labelled "egress-internal-only" should be able
+# to resolve DNS and connect to the unprotected-webserver:80 service, but not
+# unprotected-webserver:81 or public internet webservers.
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -13,16 +12,21 @@ spec:
       test-name: egress-internal-only
   egress:
     - to:
-        - ipBlock:
-            cidr: 10.0.0.0/8
-        - ipBlock:
-            cidr: 172.16.0.0/12
-        - ipBlock:
-            cidr: 192.168.0.0/16
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
       ports:
-        - protocol: TCP
-          port: 80
         - protocol: TCP
           port: 53
         - protocol: UDP
           port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: unprotected-webserver
+      ports:
+        - protocol: TCP
+          port: 80

--- a/test-netpol-enforcement/templates/tests/test-netpol-block-egress.yaml
+++ b/test-netpol-enforcement/templates/tests/test-netpol-block-egress.yaml
@@ -11,7 +11,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: busybox
-      image: busybox
+      image: docker.io/busybox:latest
       command:
         - sh
         - -c
@@ -34,7 +34,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: busybox
-      image: busybox
+      image: docker.io/busybox:latest
       command:
         - sh
         - -c
@@ -57,7 +57,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: busybox
-      image: busybox
+      image: docker.io/busybox:latest
       command:
         - sh
         - -c
@@ -85,7 +85,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: busybox
-      image: busybox
+      image: docker.io/busybox:latest
       command:
         - sh
         - -c

--- a/test-netpol-enforcement/templates/tests/test-netpol-protected-webserver.yaml
+++ b/test-netpol-enforcement/templates/tests/test-netpol-protected-webserver.yaml
@@ -11,7 +11,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: busybox
-      image: busybox
+      image: docker.io/busybox:latest
       command:
         - sh
         - -c
@@ -31,7 +31,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: busybox
-      image: busybox
+      image: docker.io/busybox:latest
       command:
         - sh
         - -c

--- a/test-netpol-enforcement/templates/unprotected-webserver.yaml
+++ b/test-netpol-enforcement/templates/unprotected-webserver.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "nginx:{{ .Chart.AppVersion }}"
+          image: docker.io/nginx:latest
           ports:
             - name: http
               containerPort: 80
@@ -54,7 +54,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "nginx:{{ .Chart.AppVersion }}"
+          image: docker.io/nginx:latest
           command:
             - sh
             - -c


### PR DESCRIPTION
Working on https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/3883 I wanted to better understand the intermittent issue, which led into thinking about kube-proxy and calico etc, and thinking that cilium may not have the same race conditions. So, hoping to see if we can use cilium instead of calico and avoid the intermittent issue without a workaround adding `sleep 10s` to traefik in the autohttps pod.